### PR TITLE
Escape characters and typos

### DIFF
--- a/Instructions/206972C_LAB_02.md
+++ b/Instructions/206972C_LAB_02.md
@@ -57,34 +57,47 @@ Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-
   
  In this exercise, your task is to configure an answer file to use for an unattended deployment of Windows 10 on a reference computer. As a starting point, you were provided with an answer file that already has the following settings configured.
 
-**Component**                                                   **Property**         **Value**
---------------------------------------------------------------- -------------------- ---------------------
+----------------------------------------------------------------------------------------------------
+**Component**                                                   **Property**         **Value**      
+--------------------------------------------------------------- -------------------- ---------------
 **amd64_Microsoft-Windows-International-Core-WinPE_neutral**    **InputLocale**      en-Us
                                                                 **SystemLocale**     en-Us
                                                                 **UILanguage**       en-Us
                                                                 **UserLocale**       en-US
+
 **amd64_Microsoft-Windows-International-Core-WinPE_neutral\\**  **UILanguage**       en-US
-SetupUILanguage**
+**SetupUILanguage**
+
 **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **DiskID**           0
 **Disk**                                                        **WillWipeDisk**     True
+
 **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **Extend**           True
+
 **Disk\\Create Partitions\\CreatePartition**                    **Order**            1
                                                                 **Type**             Primary
+
 **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **Active**           True
+
 **Disk\\ModifyPartitions\\ModifyPartition**                     **Format**           NTFS
                                                                 **Order**            1
                                                                 **Partition ID**     1
+
 **amd64_Microsoft-Windows-Setup_neutral\\ImageInstall\\**       **DiskID**           0
+
 **OSImage\\InstallTo**                                          **PartitionID**      1
+
 **amd64_Microsoft-Windows-Setup_neutral\\UserData**             **AcceptEULA**       True
+
 **amd64_Microsoft-Windows-Shell-Setup_neutral\\OOBE**           **SkipMachineOOBE**  True
                                                                 **SkipUserOOBE**     True
+
 **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\** **DisplayName**      Admin
 **LocalAccounts\\LocalAccount**                                 **Group**            Administrators
                                                                 **Name**             Admin
+
 **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\** **Value**            Pa55w.rd
 **LocalAccounts\\LocalAccount\\Password**
-
+----------------------------------------------------------------------------------------------------
 
 You need to modify the answer file and configure the following settings.
 

--- a/Instructions/206972C_LAB_02.md
+++ b/Instructions/206972C_LAB_02.md
@@ -55,63 +55,61 @@ Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-
   
 ### Scenario
   
- In this exercise, your task is to configure an answer file to use for an unattended deployment of Windows 10 on a reference computer. As a starting point, you were provided with an answer file that already has the following settings configured.
+ In this exercise, your task is to configure an answer file to use for an unattended deployment of Windows 10 on a reference computer.
+ 
+As a starting point, you were provided with an answer file that already has the following settings configured:
 
-+---------------------------------------------------------------+--------------------+---------------+
-|**Component**                                                  |**Property**        |**Value**      |
-+---------------------------------------------------------------+--------------------+---------------+
-|**amd64_Microsoft-Windows-International-Core-WinPE_neutral**   |**InputLocale**     |en-Us          |
-|                                                               |**SystemLocale**    |en-Us          |
-|                                                               |**UILanguage**      |en-Us          |
-|                                                               |**UserLocale**      |en-US          |
-+---------------------------------------------------------------+--------------------+---------------+
+  + **amd64_Microsoft-Windows-International-Core-WinPE_neutral**   
+    - **InputLocale**:     en-US
+    - **SystemLocale**:    en-US
+    - **UILanguage**:      en-US
+    - **UserLocale**:      en-US
+  + **amd64_Microsoft-Windows-International-Core-WinPE_neutral\\SetupUILanguage**
+    - **UILanguage**:      en-US
+  + **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk**
+    - **DiskID**:          0
+    - **WillWipeDisk**:    True
+  + **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**
+    - **Extend**:          True
+  + **Disk\\Create Partitions\\CreatePartition**
+    - **Order**:           1
+    - **Type**:            Primary
+  + **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**
+    - **Active**:          True
+  + **Disk\\ModifyPartitions\\ModifyPartition**
+    - **Format**:          NTFS
+    - **Order**:           1
+    - **Partition ID**:    1
+  + **amd64_Microsoft-Windows-Setup_neutral\\ImageInstall\\**
+    - **DiskID**:          0
+  + **OSImage\\InstallTo**
+    - **PartitionID**:     1
+  + **amd64_Microsoft-Windows-Setup_neutral\\UserData**
+    - **AcceptEULA**:      True
+  + **amd64_Microsoft-Windows-Shell-Setup_neutral\\OOBE**
+    - **SkipMachineOOBE**: True
+    - **SkipUserOOBE**:    True
+  + **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\LocalAccounts\\LocalAccount**
+    - **DisplayName**:     Admin
+    - **Group**:           Administrators
+    - **Name**:            Admin
+  + **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\LocalAccounts\\LocalAccount\\Password**
+    - **Value**:           Pa55w.rd
 
-|**amd64_Microsoft-Windows-International-Core-WinPE_neutral\\**  **UILanguage**       en-US
-**SetupUILanguage**
 
-**amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **DiskID**           0
-**Disk**                                                        **WillWipeDisk**     True
+You need to modify the answer file and configure the following settings:
 
-**amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **Extend**           True
+  + **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk\\Create Partitions\\CreatePartition**
+    - **Extend**:          False
+    - **Size**:            99000
+  + **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk\\ModifyPartitions\\ModifyPartition**
+    - **Label**:           Windows 10
+  + **amd64_Microsoft-Windows-Setup_neutral\\UserData**
+    - **FullName**:        _&lt;Your name&gt;_
+    - **Organization**:    _&lt;Your company&gt;_
+  + **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\LocalAccounts\\LocalAccount** 
+    - **Description**:     My local Admin
 
-**Disk\\Create Partitions\\CreatePartition**                    **Order**            1
-                                                                **Type**             Primary
-
-**amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **Active**           True
-
-**Disk\\ModifyPartitions\\ModifyPartition**                     **Format**           NTFS
-                                                                **Order**            1
-                                                                **Partition ID**     1
-
-**amd64_Microsoft-Windows-Setup_neutral\\ImageInstall\\**       **DiskID**           0
-
-**OSImage\\InstallTo**                                          **PartitionID**      1
-
-**amd64_Microsoft-Windows-Setup_neutral\\UserData**             **AcceptEULA**       True
-
-**amd64_Microsoft-Windows-Shell-Setup_neutral\\OOBE**           **SkipMachineOOBE**  True
-                                                                **SkipUserOOBE**     True
-
-**amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\** **DisplayName**      Admin
-**LocalAccounts\\LocalAccount**                                 **Group**            Administrators
-                                                                **Name**             Admin
-
-**amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\** **Value**            Pa55w.rd
-**LocalAccounts\\LocalAccount\\Password**
-----------------------------------------------------------------------------------------------------
-
-You need to modify the answer file and configure the following settings.
-
-**Component**                                                   **Property**         **Value**
---------------------------------------------------------------- -------------------- ---------------------
-**amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **Extend**           False
-**Disk\\Create Partitions\\CreatePartition**                    **Size**             99000
-**amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **Label**            Windows 10
-**Disk\\ModifyPartitions\\ModifyPartition**
-**amd64_Microsoft-Windows-Setup_neutral\\UserData**             **FullName**         _&lt;Your name&gt;_
-                                                                **Organization**     _&lt;Your company&gt;_
-**amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\** **Description**      My local Admin
-**LocalAccounts\\LocalAccount**
 
 
  The main tasks for this exercise are as follows:

--- a/Instructions/206972C_LAB_02.md
+++ b/Instructions/206972C_LAB_02.md
@@ -134,7 +134,7 @@ You need to modify the answer file and configure the following settings:
   
 1. On  **LON-CL1**, use File Explorer to format  **Floppy Disk Drive (A:)**.
 
-2. Use  **Windows System Image Manager** to open the **Autounattend.xml** answer file ** **on  **E:\\Labfiles\\Mod02**.
+2. Use  **Windows System Image Manager** to open the **Autounattend.xml** answer file on  **E:\\Labfiles\\Mod02**.
 
 3. In the  **Answer File** section of Windows SIM, verify that the answer file is configured with the parameters that were specified in the first table in the exercise scenario.
 
@@ -342,7 +342,7 @@ You also need to demonstrate to coworkers the benefits of the Windows image file
 
 4. Use the  **Add-WindowsImage** cmdlet to add the contents of the **C:\\Windows\\INF** folder as a second image to the **C:\\image.wim** file, and then use **Second Image** as the image name.
 
-5. View the size of the  **C:\\image.wim** file, ** **and then consider the benefits of single instancing when multiple images in the same Windows image file have the same files.
+5. View the size of the  **C:\\image.wim** file, and then consider the benefits of single instancing when multiple images in the same Windows image file have the same files.
 
 6. Use the  **Get-WindowsImage** cmdlet to view information about the images that are in the  **C:\\image.wim** Windows image file.
 

--- a/Instructions/206972C_LAB_02.md
+++ b/Instructions/206972C_LAB_02.md
@@ -1,4 +1,4 @@
-# Module 2: Traditional Windows 10 deployment in an enterprise
+﻿# Module 2: Traditional Windows 10 deployment in an enterprise
 # Lab: Deploying Windows 10 by using Windows ADK tools
   
 ### Scenario
@@ -21,9 +21,9 @@
   
  Estimated Time: 70 minutes
 
-Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-CL3**,  **20697-2C-LON-CL4**, ** **and  **20697-2C-LON-CL5**
+Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-CL3**,  **20697-2C-LON-CL4**, and  **20697-2C-LON-CL5**
 
- Usernames:  **Adatum\Administrator**,  **Admin**
+ Usernames:  **Adatum\\Administrator**,  **Admin**
 
  Password:  **Pa55w.rd**
 
@@ -47,7 +47,7 @@ Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-
 
 5. Repeat steps 2 through 4 for  **20697-2C-LON-CL1**. 
 
-6. For ** 20697-2C-LON-CL3** and **20697-2C-LON-CL4**, ** **perform steps 2 and 3, and then sign in as  **Admin** with the password **Pa55w.rd**. You won’t start  **20697-2C-LON-CL5** until directed to do so in the lab steps.
+6. For **20697-2C-LON-CL3** and **20697-2C-LON-CL4**, perform steps 2 and 3, and then sign in as  **Admin** with the password **Pa55w.rd**. You won’t start  **20697-2C-LON-CL5** until directed to do so in the lab steps.
 
 
 
@@ -63,7 +63,7 @@ Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-
 
  **Value**
 
- **amd64_Microsoft-Windows-International-Core-WinPE_neutral**
+  **amd64_Microsoft-Windows-International-Core-WinPE_neutral**
 
  **InputLocale**
 
@@ -81,13 +81,13 @@ en-US
 
  en-US
 
- **amd64_Microsoft-Windows-International-Core-WinPE_neutral\SetupUILanguage**
+ **amd64_Microsoft-Windows-International-Core-WinPE_neutral\\SetupUILanguage**
 
  **UILanguage**
 
 en-US
 
- **amd64_Microsoft-Windows-Setup_neutral\DiskConfiguration\Disk**
+ **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk**
 
  **DiskID**
 
@@ -97,7 +97,7 @@ en-US
 
  True
 
- **amd64_Microsoft-Windows-Setup_neutral\DiskConfiguration\Disk\Create Partitions\CreatePartition**
+ **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk\\Create Partitions\\CreatePartition**
 
  **Extend**
 
@@ -111,7 +111,7 @@ True
 
 Primary
 
- **amd64_Microsoft-Windows-Setup_neutral\DiskConfiguration\Disk\ModifyPartitions\ModifyPartition**
+ **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk\\ModifyPartitions\\ModifyPartition**
 
  **Active**
 
@@ -129,7 +129,7 @@ True
 
  1
 
- **amd64_Microsoft-Windows-Setup_neutral\ImageInstall\OSImage\InstallTo**
+ **amd64_Microsoft-Windows-Setup_neutral\\ImageInstall\\OSImage\\InstallTo**
 
  **DiskID**
 
@@ -139,13 +139,13 @@ True
 
  1
 
- **amd64_Microsoft-Windows-Setup_neutral\UserData**
+ **amd64_Microsoft-Windows-Setup_neutral\\UserData**
 
  **AcceptEULA**
 
 True
 
- **amd64_Microsoft-Windows-Shell-Setup_neutral\OOBE**
+ **amd64_Microsoft-Windows-Shell-Setup_neutral\\OOBE**
 
  **SkipMachineOOBE**
 
@@ -155,7 +155,7 @@ True
 
  True
 
- **amd64_Microsoft-Windows-Shell-Setup_neutral\UserAccounts\LocalAccounts\LocalAccount**
+ **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\LocalAccounts\\LocalAccount**
 
  **DisplayName**
 
@@ -169,7 +169,7 @@ Admin
 
 Admin
 
- **amd64_Microsoft-Windows-Shell-Setup_neutral\UserAccounts\LocalAccounts\LocalAccount\Password**
+ **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\LocalAccounts\\LocalAccount\\Password**
 
  **Value**
 
@@ -183,7 +183,7 @@ Pa55w.rd
 
  **Value**
 
- **amd64_Microsoft-Windows-Setup_neutral\DiskConfiguration\Disk\Create Partitions\CreatePartition**
+ **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk\\Create Partitions\\CreatePartition**
 
  **Extend**
 
@@ -193,13 +193,13 @@ False
 
  99000
 
- **amd64_Microsoft-Windows-Setup_neutral\DiskConfiguration\Disk\ModifyPartitions\ModifyPartition**
+ **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk\\ModifyPartitions\\ModifyPartition**
 
  **Label**
 
 Windows 10
 
- **amd64_Microsoft-Windows-Setup_neutral\UserData**
+ **amd64_Microsoft-Windows-Setup_neutral\\UserData**
 
  **FullName**
 
@@ -209,7 +209,7 @@ Windows 10
 
   _&lt;Your company&gt;_
 
- **amd64_Microsoft-Windows-Shell-Setup_neutral\UserAccounts\LocalAccounts\LocalAccount**
+ **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\LocalAccounts\\LocalAccount**
 
  **Description**
 
@@ -229,7 +229,7 @@ My local Admin
   
 1. On the host computer, use the  **Hyper-V Manager** console to open the **Settings** page for **20697-2C-LON-CL1**.
 
-2. In the  **Settings for 20697-2C-LON-CL1** dialog box, select **Diskette Drive**, and then attach the virtual floppy disk named  **VFloppy.vfd** found at **D:\Program Files\Microsoft Learning\20697-2\Drives**.
+2. In the  **Settings for 20697-2C-LON-CL1** dialog box, select **Diskette Drive**, and then attach the virtual floppy disk named  **VFloppy.vfd** found at **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives**.
 
 
 
@@ -237,7 +237,7 @@ My local Admin
   
 1. On  **LON-CL1**, use File Explorer to format  **Floppy Disk Drive (A:)**.
 
-2. Use  **Windows System Image Manager** to open the **Autounattend.xml** answer file ** **on  **E:\Labfiles\Mod02**.
+2. Use  **Windows System Image Manager** to open the **Autounattend.xml** answer file ** **on  **E:\\Labfiles\\Mod02**.
 
 3. In the  **Answer File** section of Windows SIM, verify that the answer file is configured with the parameters that were specified in the first table in the exercise scenario.
 
@@ -245,7 +245,7 @@ My local Admin
 
 5. In Windows SIM, save the answer file, and then close Windows SIM.
 
-6. Open  **File Explorer** and browse to **E:\Labfiles\Mod02**.
+6. Open  **File Explorer** and browse to **E:\\Labfiles\\Mod02**.
 
 7. Copy  **Autounattend.xml** to **Floppy Disk Drive (A:)**. 
 
@@ -255,9 +255,9 @@ My local Admin
 
 #### Task 3: Start a Windows 10 installation on the reference computer by using the answer file
   
-1. On the host computer, attach the virtual floppy disk  **VFloppy.vfd**, located in the  **D:\Program Files\Microsoft Learning\20697-2\Drives** folder, to **20697-2C-LON-CL5**.
+1. On the host computer, attach the virtual floppy disk  **VFloppy.vfd**, located in the  **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives** folder, to **20697-2C-LON-CL5**.
 
-2. Attach the  **Win10_1907_Eval.iso** DVD disk, located in the **D:\Program Files\Microsoft Learning\20697-2\Drives** folder, to **20697-2C-LON-CL5**.
+2. Attach the  **Win10_1907_Eval.iso** DVD disk, located in the **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives** folder, to **20697-2C-LON-CL5**.
 
 3. Start  **20697-2C-LON-CL5**. Verify that you aren’t prompted for any information during installation. While Windows 10 installs, continue with the next exercise. 
 
@@ -306,7 +306,7 @@ My local Admin
 
 #### Task 2: Create a provisioning package
   
-1. On the host computer, use the  **Hyper-V Manager** console to attach the virtual floppy disk **Transfer.vfd**, located in the  **D:\Program Files\Microsoft Learning\20697-2\Drives** folder, to the **20697-2C-LON-CL1** virtual machine.
+1. On the host computer, use the  **Hyper-V Manager** console to attach the virtual floppy disk **Transfer.vfd**, located in the  **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives** folder, to the **20697-2C-LON-CL1** virtual machine.
 
 2. On  **LON-CL1**, use Windows Configuration Designer to create a provisioning package that includes the following settings:
 
@@ -317,30 +317,30 @@ My local Admin
 
   - To which OU the computer account should be added:  **Computers** OU that is in the **Marketing** OU in the **Adatum.com** domain
 
-  - Use username  **Adatum\Ada** with password **Pa55w.rd** to add the computer to the domain.
+  - Use username  **Adatum\\Ada** with password **Pa55w.rd** to add the computer to the domain.
 
-  - Add the local users named  **LocalUser** and ** _&lt;Your name&gt;_**with the password  **Pa55w.rd**.
+  - Add the local users named  **LocalUser** and **_&lt;Your name&gt;_**, with the password  **Pa55w.rd**.
 
-  - Add the  **E:\Labfiles\Mod02\report.txt** file to the **Public Documents** folder.
+  - Add the  **E:\\Labfiles\\Mod02\\report.txt** file to the **Public Documents** folder.
 
 
 1. Export the provisioning package, and then save it to the virtual floppy disk as  **Marketing Computer.ppkg**.
 
-2. Eject the  **Transfer.vfd** virtual ** **floppy disk from the  **20697-2C-LON-CL1** virtual machine.
+2. Eject the  **Transfer.vfd** virtual floppy disk from the  **20697-2C-LON-CL1** virtual machine.
 
 
 
 #### Task 3: Install the provisioning package
   
-1. Insert the virtual floppy disk  **Transfer.vfd**, which is located on the host, in the  **D:\Program Files\Microsoft Learning\20697-2\Drivers** folder on the **20697-2C-LON-CL4** virtual machine.
+1. Insert the virtual floppy disk  **Transfer.vfd**, which is located on the host, in the  **D:\\Program Files\\Microsoft Learning\\20697-2\\Drivers** folder on the **20697-2C-LON-CL4** virtual machine.
 
 2. On  **LON-CL4**, use File Explorer to install the  **Marketing Computer.ppkg** provisioning package that is on the virtual floppy disk.
 
 3. Wait until  **LON-CL4** restarts, and then sign in to **LON-CL4** as **Admin** with the password **Pa55w.rd**.
 
-4. Eject the  **Transfer.vfd** virtual ** **floppy disk from the  **20697-2C-LON-CL4** virtual machine.
+4. Eject the  **Transfer.vfd** virtual floppy disk from the  **20697-2C-LON-CL4** virtual machine.
 
-5. Insert the virtual floppy disk  **Transfer.vfd**, which is located on the host, in the  **D:\Program Files\Microsoft Learning\20697-2\Drivers** folder on the **20697-2C-LON-CL3** virtual machine.
+5. Insert the virtual floppy disk  **Transfer.vfd**, which is located on the host, in the  **D:\\Program Files\\Microsoft Learning\\20697-2\\Drivers** folder on the **20697-2C-LON-CL3** virtual machine.
 
 6. On  **LON-CL3**, use the Settings app to add the  **Marketing Computer.ppkg** provisioning package that is on the removable media.
 
@@ -351,12 +351,14 @@ My local Admin
 #### Task 4: Verify that the computer was provisioned
   
 1. On  **LON-DC1**, use Active Directory Users and Computers to verify that the  **Computers** OU inside the **Marketing** OU contains two computer accounts. The names of both the computers start with **MARKETING-** followed by three digits.
+
 >  **Note:** If the **Computers** OU is empty, right-click the OU, and then select **Refresh**.
+
 2. On  **LON-CL4**, verify that the computer name is  **Marketing-** followed by three digits and that the computer is in the **Adatum.com** domain.
 
 3. Verify that  **LON-CL4** has a local account with your name and an account named **LocalUser**.
 
-4. Verify that the ** Public Documents** folder on **LON-CL4** contains the **Report.txt** file.
+4. Verify that the **Public Documents** folder on **LON-CL4** contains the **Report.txt** file.
 
 
 >  **Result**: After completing this exercise, you should have successfully used Windows Configuration Designer to create a provisioning package and applied the provisioning package.
@@ -392,14 +394,16 @@ You also need to demonstrate to coworkers the benefits of the Windows image file
 
 2. Verify that  **LON-CL5** is installed per the settings that you specified in the answer file. Verify the following settings:
 
-  - Windows 10 licensed to:  ** _&lt;Your name&gt;_**
+  - Windows 10 licensed to:  **_&lt;Your name&gt;_**
 
   - Volume C label:  **Windows 10**
 
   - Volume C capacity:  **96.6 GB**
 
   - User Admin description:  **My local Admin**
+
 >  **Note:** In the answer file, you specified that the volume should have a size of 99,000 megabytes (MB). 1 GB is 1,024 MB and therefore 96.6 GB is approximately 99,000 MB.
+
 3. Run  **Sysprep.exe**, specify the option to generalize the installation, and then shut down the computer after the generalization.
 
 4. After the  **LON-CL5** virtual machine is turned off, create a virtual machine checkpoint, and then name it **Generalized**.
@@ -408,20 +412,20 @@ You also need to demonstrate to coworkers the benefits of the Windows image file
 
 #### Task 2: Capture the reference computer image
   
-1. Add the Windows PE media to  **LON-CL5** by attaching the DVD image file found at **D:\Program Files\Microsoft Learning\20697-2\Drives\WindowsPE.iso**.
+1. Add the Windows PE media to  **LON-CL5** by attaching the DVD image file found at **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives\\WindowsPE.iso**.
 
 2. Start  **LON-CL5** from the DVD media.
 
-3. On  **LON-CL5**, ** **use the  **Adatum\Administrator** and **Pa55w.rd** credentials to ** **connect drive G to  **\\lon-cl1\Images**.
+3. On  **LON-CL5**, use the  **Adatum\\Administrator** and **Pa55w.rd** credentials to connect drive G to  **\\\\lon-cl1\\Images**.
 
-4. Use  **Dism.exe** with the _Capture-Image_ ** **parameter to capture drive C to the  **G:\Reference.wim** Windows image file, and then name the image **Reference Image**.
+4. Use  **Dism.exe** with the _Capture-Image_ parameter to capture drive C to the  **G:\\Reference.wim** Windows image file, and then name the image **Reference Image**.
 
 >  **Note:** You can continue with the lab while the capture is in progress.
 
 
 #### Task 3: View information about the default Windows 10 image
   
-1. Add the Windows 10 DVD media to  **LON-CL1** by attaching the DVD image file at **D:\Program Files\Microsoft Learning\20697-2\Drives\Win10_1709_Eval.iso**.
+1. Add the Windows 10 DVD media to  **LON-CL1** by attaching the DVD image file at **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives\\Win10_1709_Eval.iso**.
 
 2. Use File Explorer to view the properties of the  **install.wim** file in the **sources** folder on the DVD drive.
 
@@ -433,35 +437,35 @@ You also need to demonstrate to coworkers the benefits of the Windows image file
 
 #### Task 4: Capture the custom image
   
-1. Use the  **New-WindowsImage** cmdlet ** **with the  _CapturePath_ ** **parameter to capture the contents of the  **C:\Windows\INF** folder in a file named **C:\image.wim**, and then name the image  **First image**.
+1. Use the  **New-WindowsImage** cmdlet with the  _CapturePath_ parameter to capture the contents of the  **C:\\Windows\\INF** folder in a file named **C:\\image.wim**, and then name the image  **First image**.
 
-2. Use File Explorer ** **to view the properties of the  **C:\Windows\INF** folder.
+2. Use File Explorer to view the properties of the  **C:\\Windows\\INF** folder.
 
-3. View the size of the  **C:\image.wim** file, and then consider the benefits of Windows image file format compression.
+3. View the size of the  **C:\\image.wim** file, and then consider the benefits of Windows image file format compression.
 
-4. Use the  **Add-WindowsImage** cmdlet to add the contents of the **C:\Windows\INF** folder as a second image to the **C:\image.wim** file, and then use **Second Image** as the image name.
+4. Use the  **Add-WindowsImage** cmdlet to add the contents of the **C:\\Windows\\INF** folder as a second image to the **C:\\image.wim** file, and then use **Second Image** as the image name.
 
-5. View the size of the  **C:\image.wim** file, ** **and then consider the benefits of single instancing when multiple images in the same Windows image file have the same files.
+5. View the size of the  **C:\\image.wim** file, ** **and then consider the benefits of single instancing when multiple images in the same Windows image file have the same files.
 
-6. Use the  **Get-WindowsImage** cmdlet ** **to view information about the images that are in the  **C:\image.wim** Windows image file.
+6. Use the  **Get-WindowsImage** cmdlet to view information about the images that are in the  **C:\\image.wim** Windows image file.
 
 
 
 #### Task 5: Service and update the image
   
-1. On  **LON-CL1**, use File Explorer ** **to view the properties of the  **C:\image.wim** file, including its size and date of last modification.
+1. On  **LON-CL1**, use File Explorer to view the properties of the  **C:\\image.wim** file, including its size and date of last modification.
 
-2. Create a folder named  **C:\mount**, and then use  **Dism.exe** with the _Mount-Wim_ parameter to mount the second image in the **C:\image.wim** file to the **C:\mount** folder.
+2. Create a folder named  **C:\\mount**, and then use  **Dism.exe** with the _Mount-Wim_ parameter to mount the second image in the **C:\\image.wim** file to the **C:\\mount** folder.
 
-3. Use File Explorer ** **to view the properties of the  **C:\mount** folder.
+3. Use File Explorer to view the properties of the  **C:\\mount** folder.
 
-4. In the  **C:\mount** folder, create a subfolder named **Folder1**. ** **Delete the files ** **named  **1394.PNF**,  **acpi.PNF**, and  **acpidev.PNF** in the **C:\mount** folder.
+4. In the  **C:\\mount** folder, create a subfolder named **Folder1**. Delete the files named  **1394.PNF**,  **acpi.PNF**, and  **acpidev.PNF** in the **C:\\mount** folder.
 
-5. Use  **Dism.exe** with the _Unmount-Wim_ ** **and  _Commit_ parameters to unmount the image.
+5. Use  **Dism.exe** with the _Unmount-Wim_ and _Commit_ parameters to unmount the image.
 
-6. View the properties of  **C:\image.wim**.
+6. View the properties of  **C:\\image.wim**.
 
-7. Use  **Dism.exe** with the _Get-WimInfo_ parameter to view and compare the properties of both images in the **C:\image.wim** file.
+7. Use  **Dism.exe** with the _Get-WimInfo_ parameter to view and compare the properties of both images in the **C:\\image.wim** file.
 
 
 
@@ -475,7 +479,7 @@ You also need to demonstrate to coworkers the benefits of the Windows image file
 
 3. In the  **Revert Virtual Machines** dialog box, click **Revert**.
 
-4. Repeat steps 2 and 3 for  **20697-2C-LON-CL1, 20697-2C-LON-CL3, 20697-2C-LON-CL4,** and ** 20697-2C-LON-CL5.**
+4. Repeat steps 2 and 3 for  **20697-2C-LON-CL1**, **20697-2C-LON-CL3**, **20697-2C-LON-CL4**, and **20697-2C-LON-CL5**.
 
 
 >  **Result**: After completing this exercise, you should have successfully generalized and captured an image of the reference computer. You should have also performed offline servicing of the image.

--- a/Instructions/206972C_LAB_02.md
+++ b/Instructions/206972C_LAB_02.md
@@ -57,15 +57,16 @@ Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-
   
  In this exercise, your task is to configure an answer file to use for an unattended deployment of Windows 10 on a reference computer. As a starting point, you were provided with an answer file that already has the following settings configured.
 
-----------------------------------------------------------------------------------------------------
-**Component**                                                   **Property**         **Value**      
---------------------------------------------------------------- -------------------- ---------------
-**amd64_Microsoft-Windows-International-Core-WinPE_neutral**    **InputLocale**      en-Us
-                                                                **SystemLocale**     en-Us
-                                                                **UILanguage**       en-Us
-                                                                **UserLocale**       en-US
++---------------------------------------------------------------+--------------------+---------------+
+|**Component**                                                  |**Property**        |**Value**      |
++---------------------------------------------------------------+--------------------+---------------+
+|**amd64_Microsoft-Windows-International-Core-WinPE_neutral**   |**InputLocale**     |en-Us          |
+|                                                               |**SystemLocale**    |en-Us          |
+|                                                               |**UILanguage**      |en-Us          |
+|                                                               |**UserLocale**      |en-US          |
++---------------------------------------------------------------+--------------------+---------------+
 
-**amd64_Microsoft-Windows-International-Core-WinPE_neutral\\**  **UILanguage**       en-US
+|**amd64_Microsoft-Windows-International-Core-WinPE_neutral\\**  **UILanguage**       en-US
 **SetupUILanguage**
 
 **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **DiskID**           0

--- a/Instructions/206972C_LAB_02.md
+++ b/Instructions/206972C_LAB_02.md
@@ -57,159 +57,48 @@ Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-
   
  In this exercise, your task is to configure an answer file to use for an unattended deployment of Windows 10 on a reference computer. As a starting point, you were provided with an answer file that already has the following settings configured.
 
- |**Component**|**Property**|**Value**|
+**Component**                                                   **Property**         **Value**
+--------------------------------------------------------------- -------------------- ---------------------
+**amd64_Microsoft-Windows-International-Core-WinPE_neutral**    **InputLocale**      en-Us
+                                                                **SystemLocale**     en-Us
+                                                                **UILanguage**       en-Us
+                                                                **UserLocale**       en-US
+**amd64_Microsoft-Windows-International-Core-WinPE_neutral\\**  **UILanguage**       en-US
+SetupUILanguage**
+**amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **DiskID**           0
+**Disk**                                                        **WillWipeDisk**     True
+**amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **Extend**           True
+**Disk\\Create Partitions\\CreatePartition**                    **Order**            1
+                                                                **Type**             Primary
+**amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **Active**           True
+**Disk\\ModifyPartitions\\ModifyPartition**                     **Format**           NTFS
+                                                                **Order**            1
+                                                                **Partition ID**     1
+**amd64_Microsoft-Windows-Setup_neutral\\ImageInstall\\**       **DiskID**           0
+**OSImage\\InstallTo**                                          **PartitionID**      1
+**amd64_Microsoft-Windows-Setup_neutral\\UserData**             **AcceptEULA**       True
+**amd64_Microsoft-Windows-Shell-Setup_neutral\\OOBE**           **SkipMachineOOBE**  True
+                                                                **SkipUserOOBE**     True
+**amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\** **DisplayName**      Admin
+**LocalAccounts\\LocalAccount**                                 **Group**            Administrators
+                                                                **Name**             Admin
+**amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\** **Value**            Pa55w.rd
+**LocalAccounts\\LocalAccount\\Password**
+
+
+You need to modify the answer file and configure the following settings.
+
+**Component**                                                   **Property**         **Value**
+--------------------------------------------------------------- -------------------- ---------------------
+**amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **Extend**           False
+**Disk\\Create Partitions\\CreatePartition**                    **Size**             99000
+**amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\**  **Label**            Windows 10
+**Disk\\ModifyPartitions\\ModifyPartition**
+**amd64_Microsoft-Windows-Setup_neutral\\UserData**             **FullName**         _&lt;Your name&gt;_
+                                                                **Organization**     _&lt;Your company&gt;_
+**amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\** **Description**      My local Admin
+**LocalAccounts\\LocalAccount**
 
- |**amd64_Microsoft-Windows-International-Core-WinPE_neutral**|||
-
- ||**InputLocale**|en-us|
-
- ||**SystemLocale**|en-us|
-
- ||**UILanguage**|en-us|
-
-  **UserLocale**
-
-en-US
-
- en-US
-
-en-US
-
- en-US
-
- **amd64_Microsoft-Windows-International-Core-WinPE_neutral\\SetupUILanguage**
-
- **UILanguage**
-
-en-US
-
- **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk**
-
- **DiskID**
-
-  **WillWipeDisk**
-
-0
-
- True
-
- **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk\\Create Partitions\\CreatePartition**
-
- **Extend**
-
-  **Order**
-
- **Type**
-
-True
-
- 1
-
-Primary
-
- **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk\\ModifyPartitions\\ModifyPartition**
-
- **Active**
-
-  **Format**
-
- **Order**
-
-  **PartitionID**
-
-True
-
- NTFS
-
-1
-
- 1
-
- **amd64_Microsoft-Windows-Setup_neutral\\ImageInstall\\OSImage\\InstallTo**
-
- **DiskID**
-
-  **PartitionID**
-
-0
-
- 1
-
- **amd64_Microsoft-Windows-Setup_neutral\\UserData**
-
- **AcceptEULA**
-
-True
-
- **amd64_Microsoft-Windows-Shell-Setup_neutral\\OOBE**
-
- **SkipMachineOOBE**
-
-  **SkipUserOOBE**
-
-True
-
- True
-
- **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\LocalAccounts\\LocalAccount**
-
- **DisplayName**
-
-  **Group**
-
- **Name**
-
-Admin
-
- Administrators
-
-Admin
-
- **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\LocalAccounts\\LocalAccount\\Password**
-
- **Value**
-
-Pa55w.rd
-
- You need to modify the answer file and configure the following settings.
-
- **Component**
-
- **Property**
-
- **Value**
-
- **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk\\Create Partitions\\CreatePartition**
-
- **Extend**
-
-  **Size**
-
-False
-
- 99000
-
- **amd64_Microsoft-Windows-Setup_neutral\\DiskConfiguration\\Disk\\ModifyPartitions\\ModifyPartition**
-
- **Label**
-
-Windows 10
-
- **amd64_Microsoft-Windows-Setup_neutral\\UserData**
-
- **FullName**
-
-  **Organization**
-
- _&lt;Your name&gt;_
-
-  _&lt;Your company&gt;_
-
- **amd64_Microsoft-Windows-Shell-Setup_neutral\\UserAccounts\\LocalAccounts\\LocalAccount**
-
- **Description**
-
-My local Admin
 
  The main tasks for this exercise are as follows:
 

--- a/Instructions/206972C_LAB_02.md
+++ b/Instructions/206972C_LAB_02.md
@@ -61,11 +61,11 @@ Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-
 
  |**amd64_Microsoft-Windows-International-Core-WinPE_neutral**|||
 
-||**InputLocale**|en-us|
+ ||**InputLocale**|en-us|
 
-||**SystemLocale**|en-us|
+ ||**SystemLocale**|en-us|
 
-||**UILanguage**|en-us|
+ ||**UILanguage**|en-us|
 
   **UserLocale**
 

--- a/Instructions/206972C_LAB_02.md
+++ b/Instructions/206972C_LAB_02.md
@@ -57,19 +57,15 @@ Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-
   
  In this exercise, your task is to configure an answer file to use for an unattended deployment of Windows 10 on a reference computer. As a starting point, you were provided with an answer file that already has the following settings configured.
 
- **Component**
+ |**Component**|**Property**|**Value**|
 
- **Property**
+ |**amd64_Microsoft-Windows-International-Core-WinPE_neutral**|||
 
- **Value**
+||**InputLocale**|en-us|
 
-  **amd64_Microsoft-Windows-International-Core-WinPE_neutral**
+||**SystemLocale**|en-us|
 
- **InputLocale**
-
-  **SystemLocale**
-
- **UILanguage**
+||**UILanguage**|en-us|
 
   **UserLocale**
 

--- a/Instructions/206972C_LAB_02.md
+++ b/Instructions/206972C_LAB_02.md
@@ -23,9 +23,9 @@
 
 Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-CL3**,  **20697-2C-LON-CL4**, and  **20697-2C-LON-CL5**
 
- Usernames:  **Adatum\\Administrator**,  **Admin**
+ - Usernames:  **Adatum\\Administrator**,  **Admin**
 
- Password:  **Pa55w.rd**
+ - Password:  **Pa55w.rd**
 
  For this lab, you will use the available virtual machine environment. Before you begin the lab, you must complete the following steps:
 
@@ -221,9 +221,9 @@ You need to modify the answer file and configure the following settings:
   - Add the  **E:\\Labfiles\\Mod02\\report.txt** file to the **Public Documents** folder.
 
 
-1. Export the provisioning package, and then save it to the virtual floppy disk as  **Marketing Computer.ppkg**.
+3. Export the provisioning package, and then save it to the virtual floppy disk as  **Marketing Computer.ppkg**.
 
-2. Eject the  **Transfer.vfd** virtual floppy disk from the  **20697-2C-LON-CL1** virtual machine.
+4. Eject the  **Transfer.vfd** virtual floppy disk from the  **20697-2C-LON-CL1** virtual machine.
 
 
 

--- a/Instructions/206972C_LAB_03.md
+++ b/Instructions/206972C_LAB_03.md
@@ -25,9 +25,9 @@
 
 Virtual machines:  **20697-2C-LON-DC1** and **20697-2C-LON-CL3**
 
- Usernames:  **Adatum\\Administrator** and **Admin**
+ - Usernames:  **Adatum\\Administrator** and **Admin**
 
- Password:  **Pa55w.rd**
+ - Password:  **Pa55w.rd**
 
   **Lab Setup**
 

--- a/Instructions/206972C_LAB_03.md
+++ b/Instructions/206972C_LAB_03.md
@@ -1,4 +1,4 @@
-# Module 3: Managing Windows 10 sign-in and identity
+﻿# Module 3: Managing Windows 10 sign-in and identity
 # Lab: Extending on-premises AD DS to Azure AD
   
 ### Scenario
@@ -25,7 +25,7 @@
 
 Virtual machines:  **20697-2C-LON-DC1** and **20697-2C-LON-CL3**
 
- Usernames:  **Adatum\Administrator** and **Admin**
+ Usernames:  **Adatum\\Administrator** and **Admin**
 
  Password:  **Pa55w.rd**
 
@@ -42,7 +42,7 @@ Virtual machines:  **20697-2C-LON-DC1** and **20697-2C-LON-CL3**
 4. Sign in by using the following credentials:
 
 
-  - Username:  **Adatum\Administrator**
+  - Username:  **Adatum\\Administrator**
 
   - Password:  **Pa55w.rd**
 
@@ -79,26 +79,28 @@ The main tasks for this exercise are as follows:
 
 3. Select the  **Sign up now** link, and then use the wizard to create a new Microsoft account.
 
->  **Note:** Make sure that you write down the username that you chose. For example, you can choose a username in theYourInitials-Date@outlook.com format, for example, DJ-060815@outlook.com. Make sure to note the password that you select. We recommend that you type your working email address in the **Alternate email address** text box.
+>  **Note:** Make sure that you write down the username that you chose. For example, you can choose a username in the _YourInitials-Date_@outlook.com format, for example, DJ-060815@outlook.com. Make sure to note the password that you select. We recommend that you type your working email address in the **Alternate email address** text box.
 
 
 #### Task 2: Create a trial Azure subscription
   
-1. On  **LON-CL3**, in Microsoft Edge, browse to  **http://aka.ms/cu92vo**.
+1. On  **LON-CL3**, in Microsoft Edge, browse to  [**http://aka.ms/cu92vo**](http://aka.ms/cu92vo).
 
 2. On the  **Azure Pass** page, sign in with the Microsoft account that you created in the previous task.
 
 3. Enter your promo code, and then finish creating the trial account.
 
-4. Verify that you can access the Azure portal at https://portal.azure.com.
->  **Note:** If an authentication error occurs, sign out, close all browser windows, and then sign in at https://portal.azure.com.
+4. Verify that you can access the Azure portal at [**https://portal.azure.com**](https://portal.azure.com).
+
+>  **Note:** If an authentication error occurs, sign out, close all browser windows, and then sign in at [**https://portal.azure.com**](https://portal.azure.com).
+
 5. Close Microsoft Edge.
 
 
 
 #### Task 3: Review the default Azure AD directory settings
   
-1. On  **LON-CL3**, use Microsoft Edge to connect to  **https://portal.azure.com**, and then sign in with your Microsoft account.
+1. On  **LON-CL3**, use Microsoft Edge to connect to  [**https://portal.azure.com**](https://portal.azure.com), and then sign in with your Microsoft account.
 
 2. Browse to the  **Azure Active Directory Overview** page, and then read the name of the default directory.
 
@@ -108,6 +110,7 @@ The main tasks for this exercise are as follows:
 
 
 >  **Result**: After completing this exercise, you should have successfully created an Azure Active Directory (Azure AD) tenant.
+
 
 
 ## Exercise 2: Managing Azure AD users and groups
@@ -122,7 +125,7 @@ The main tasks for this exercise are as follows:
 
 2. Create a global administrator
 
-3. Add a Microsoft Enterprise Mobility + Security trial subscription
+3. Add a **Microsoft Enterprise Mobility + Security E5** trial subscription
 
 4. Create a group with static membership
 
@@ -132,14 +135,14 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Create a standard user
   
-1. On  **LON-CL3**, on the Azure portal, browse to  **Users and groups - All users**.
+1. On  **LON-CL3**, on the Azure portal, browse to  **Users - All users**.
 
 2. Create a new user with the following information:
 
 
   - Name:  **Deanna Sheppard**
 
-  - Username:  **Deanna@yourtenant.onmicrosoft.com**
+  - Username:  **Deanna@*yourtenant*.onmicrosoft.com**
 
   - First name:  **Deanna**
 
@@ -159,32 +162,32 @@ The main tasks for this exercise are as follows:
 
   - Name:  **GAdmin**
 
-  - Username:  **GAdmin@yourtenant.onmicrosoft.com**
+  - Username:  **GAdmin@*yourtenant*.onmicrosoft.com**
 
 
-1. Directory role:  **Global administrator**
+2. Directory role:  **Global administrator**
 
-2. Note the password for later use.
+3. Note the password for later use.
 
-3. Close Microsoft Edge.
+4. Close Microsoft Edge.
 
 
 
-#### Task 3: Add a Microsoft Enterprise Mobility + Security trial subscription
+#### Task 3: Add a Microsoft Enterprise Mobility + Security E5 trial subscription
   
-1. On  **LON-CL3**, use Microsoft Edge to open  **https://portal.azure.com**, and then sign in as  **GAdmin@yourtenant.onmicrosoft.com**.
+1. On  **LON-CL3**, use Microsoft Edge to open  [**https://portal.azure.com**](https://portal.azure.com), and then sign in as  **GAdmin@*yourtenant*.onmicrosoft.com**.
 
 2. When prompted, update the password for GAdmin.
 
 3. Browse to the  **Azure Active Directory Quick Start** page.
 
-4. Select the option to create a free trial account for Azure AD Premium, select  **ENTERPRISE MOBILITY SUITE**, and then activate it. 
+4. Select the option to create a free trial account for Azure AD Premium, select  **ENTERPRISE MOBILITY + SECURITY E5**, and then activate it. 
 
 
 
 #### Task 4: Create a group with static membership
   
-1. On  **LON-CL3**, on the Azure portal, browse to  **Azure Active Directory**, and then browse to  **Users and groups - All groups**.
+1. On  **LON-CL3**, on the Azure portal, browse to  **Azure Active Directory**, and then browse to  **Groups - All groups**.
 
 2. Create a new group with the following information:
 
@@ -199,7 +202,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 5: Create a group with dynamic membership
   
-1. On  **LON-CL3**, on the Azure portal, browse to  **Azure Active Directory**, and then browse to  **Users and groups - All groups**.
+1. On  **LON-CL3**, on the Azure portal, browse to  **Azure Active Directory**, and then browse to  **Groups - All groups**.
 
 2. Create a new group with the following information:
 
@@ -211,11 +214,14 @@ The main tasks for this exercise are as follows:
   - Dynamic membership rule:  **department Equals IT**
 
 
-1. Verify that Deanna Sheppard is listed as a DynamicGroup member.
+3. Verify that Deanna Sheppard is listed as a DynamicGroup member.
 
->  **Note:** If no DynamicGroup members are listed, wait a few minutes, and then refresh the membership list. It can take several minutes for the membership to populate.
+    >  **Note:** If no DynamicGroup members are listed, wait a few minutes, and then refresh the membership list. It can take several minutes for the membership to populate.
+
+<!-- -->
 
 >  **Result**: After this exercise, you will have successfully created cloud-based users and groups.
+
 
 
 ## Exercise 3: Configuring and enabling directory synchronization
@@ -236,9 +242,9 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Update UPNs to match Azure AD
   
-1. On  **LON-DC1**, use Windows PowerShell Integrated Scripting Environment (ISE) to open  **E:\Labfiles\Mod03\UpdateUPN.ps1**.
+1. On  **LON-DC1**, use Windows PowerShell Integrated Scripting Environment (ISE) to open  **E:\\Labfiles\\Mod03\\UpdateUPN.ps1**.
 
-2. On line three of the script, replace  **yourtenant** with the name of your Azure AD tenant.
+2. On line three of the script, replace  **_yourtenant_** with the name of your Azure AD tenant.
 
 3. Save the script, and then run it.
 
@@ -248,15 +254,15 @@ The main tasks for this exercise are as follows:
 
 #### Task 2: Install Azure AD Connect
   
-1. On  **LON-DC1**, run  **E:\Labfiles\AzureADConnect.msi**.
+1. On  **LON-DC1**, run  **E:\\Labfiles\\AzureADConnect.msi**.
 
 2. Install Azure AD Connect by using the following settings:
 
   -  **Express settings**
 
-  - Azure AD account:  **GAdmin@yourtenant.onmicrosoft.com**
+  - Azure AD account:  **GAdmin@*yourtenant*.onmicrosoft.com**
 
-  - AD DS account:  **Adatum\Administrator**
+  - AD DS account:  **Adatum\\Administrator**
 
   -  **Continue without any verified domains**
 
@@ -267,12 +273,14 @@ The main tasks for this exercise are as follows:
 #### Task 3: Verify that Azure AD Connect has populated Azure AD
   
 1. On  **LON-CL3**, on the Azure portal, browse to  **Azure Active Directory**, and then view the configuration for  **Azure AD Connect**.
+
 >  **Note:** If **Sync Status** is **Not Enabled**, then wait a few moments and refresh the page.
-2. Browse to  **Users and groups**, and then verify that new users and groups have been added.
 
-3. Browse to  **All groups**, ** **and then view the DynamicGroup membership.
+2. Browse to  **Users - All users**, and then verify that new users have been added.
 
-4. Verify that new members have been added.
+3. Browse to  **Groups - All groups**, and verify that new groups have been added.
+
+4. View the **DynamicGroup** membership, and verify that new members have been added.
 
 
 
@@ -301,15 +309,15 @@ The main tasks for this exercise are as follows:
 
   -  **Join this device to Azure Active Directory**
 
-  - Username:  **Aidan@yourtenant.onmicrosoft.com**
+  - Username:  **Aidan@*yourtenant*.onmicrosoft.com**
 
   - Password:  **Pa55w.rd**
 
-3. Use Microsoft Edge to open  **https://portal.azure.com**, and then sign in as  **GAdmin@yourtenant.onmicrosoft.com**.
+3. Use Microsoft Edge to open  [**https://portal.azure.com**](https://portal.azure.com), and then sign in as  **GAdmin@*yourtenant*.onmicrosoft.com**.
 
 4. In  **Azure Active Directory**, browse to  **Devices**, and then verify that Aidan Norman is the owner of  **LON-CL3**.
 
-5. Restart  **LON-CL3**, and then sign in as  **Aidan@yourtenant.onmicrosoft.com** with the password **Pa55w.rd**.
+5. Restart  **LON-CL3**, and then sign in as  **Aidan@*yourtenant*.onmicrosoft.com** with the password **Pa55w.rd**.
 
 6. Set up a PIN if prompted to do so.
 
@@ -321,7 +329,7 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-CL3**, open the  **Microsoft Management Console**.
 
-2. Add the  **Certificates** snap-in for the ** Computer account** to the console window.
+2. Add the  **Certificates** snap-in for the **Computer account** to the console window.
 
 3. View the personal certificates store.
 

--- a/Instructions/206972C_LAB_04.md
+++ b/Instructions/206972C_LAB_04.md
@@ -1,4 +1,4 @@
-# Module 4: Managing user profiles and UE-V
+﻿# Module 4: Managing user profiles and UE-V
 # Lab A: Configuring user profiles and UE-V
   
 ### Scenario
@@ -25,20 +25,21 @@ Adatum Corporation is using Windows 10 Enterprise, and management has asked you 
   
  Estimated Time: 75 minutes
 
-Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-CL2**,  **20697-2C-LON-CL3**,  **20697-2C-LON-CL4**,  **20697-2C-LON-CL5**, and ** MT17B-WS2016-NAT**
+Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-CL2**,  **20697-2C-LON-CL3**,  **20697-2C-LON-CL4**,  **20697-2C-LON-CL5**, and **MT17B-WS2016-NAT**
 
  For  **LON-DC1**:
 
- User name:  **Adatum\Administrator**
+ - User name:  **Adatum\\Administrator**
 
- Password:  **Pa55w.rd**
+ - Password:  **Pa55w.rd**
 
  For  **LON-CL4**:
 
- User name:  **Admin**
+ - User name:  **Admin**
 
- Password:  **Pa55w.rd**
->  **Note:** Start and sign in to **LON-DC1** and ** LON-CL4**. Start the  **LON-CL1**,  **LON-CL2**,  **LON-CL3**, and ** MT17B-WS2016-NAT** virtual machines, but do not sign in to them. Do not start **LON-CL5** at this point.
+ - Password:  **Pa55w.rd**
+
+>  **Note:** Start and sign in to **LON-DC1** and **LON-CL4**. Start the  **LON-CL1**,  **LON-CL2**,  **LON-CL3**, and **MT17B-WS2016-NAT** virtual machines, but do not sign in to them. Do not start **LON-CL5** at this point.
 
 1. On the host computer, start  **Hyper-V Manager**.
 
@@ -58,12 +59,10 @@ Virtual machines:  **20697-2C-LON-DC1**,  **20697-2C-LON-CL1**,  **20697-2C-LON-
 
 5. Repeat steps 2 and 3 for  **20697-2C-LON-CL4**, and then sign in with the user name Admin and password  **Pa55w.rd**.
 
-6. Start the  **20697-2C-LON-CL1**,  **20697-2C-LON-CL2**,  **20697-2C-LON-CL3**, and ** MT17B-WS2016-NAT** virtual machines, but do not sign in to them.
+6. Start the  **20697-2C-LON-CL1**,  **20697-2C-LON-CL2**,  **20697-2C-LON-CL3**, and **MT17B-WS2016-NAT** virtual machines, but do not sign in to them.
 
 
  
-
-
 ## Exercise 1: Configuring roaming user profiles, Folder Redirection, and the primary computer setting
   
 ### Scenario
@@ -88,15 +87,15 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Prepare the infrastructure
   
-1. On  **LON-DC1**, on drive  **C**, create a folder named  **Profiles**. Grant  **Domain Users** Read/Write permissions to the folder and share it with Read/Write permissions for **Domain Users**.
+1. On  **LON-DC1**, on drive  **C:**, create a folder named  **Profiles**. Grant  **Domain Users** Read/Write permissions to the folder and share it with Read/Write permissions for **Domain Users**.
 
-2. On drive  **C**, create a folder named  **Redirected**. Grant  **Domain Users** Read/Write permissions to the folder and share it with Read/Write permissions for **Domain Users**.
+2. On drive **C:**, create a folder named  **Redirected**. Grant  **Domain Users** Read/Write permissions to the folder and share it with Read/Write permissions for **Domain Users**.
 
 
 
 #### Task 2: Configure roaming user profiles
   
-- On  **LON-DC1**, use  **Active Directory Users and Computers** to configure **Ada Russell**, who is in the  **Marketing** OU, with profile settings that point to **\\LON-DC1\Profiles\%username%**.
+1. On  **LON-DC1**, use  **Active Directory Users and Computers** to configure **Ada Russell**, who is in the  **Marketing** OU, with profile settings that point to **\\\\LON-DC1\\Profiles\\%username%**.
 
 
 
@@ -104,7 +103,7 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-DC1**, create a GPO named  **Folder Redirection**, and then link it to the  **Marketing** OU.
 
-2. Configure the  **Folder Redirection** Group Policy setting to redirect the **Documents** folder to **\\LON-DC1\Redirected**.
+2. Configure the  **Folder Redirection** Group Policy setting to redirect the **Documents** folder to **\\\\LON-DC1\\Redirected**.
 
 
 
@@ -112,13 +111,13 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-DC1**, switch to  **File Explorer** and verify that the **Profiles** and **Redirected** folders are empty.
 
-2. Sign in to  **LON-CL1** as **Adatum\Ada** with the password **Pa55w.rd**.
+2. Sign in to  **LON-CL1** as **Adatum\\Ada** with the password **Pa55w.rd**.
 
 3. On Ada’s desktop, create a folder named  **Presentations**, and then add a shortcut to  **Local Disk (C)**.
 
 4. In  **Notepad**, create a file with your name, and then save it in the  **Documents** folder.
 
-5. Verify that the file is stored in the  **\\LON-DC1\Redirected\Ada\Documents** folder and is not stored inside Ada Russell’s local profile. Also verify that the **Offline Files** tab is available in the **File Properties** dialog box.
+5. Verify that the file is stored in the  **\\\\LON-DC1\\Redirected\\Ada\\Documents** folder and is not stored inside Ada Russell’s local profile. Also verify that the **Offline Files** tab is available in the **File Properties** dialog box.
 
 6. Disconnect  **20697-2C-LON-CL1** from the virtual switch.
 
@@ -130,14 +129,16 @@ The main tasks for this exercise are as follows:
 
 10. Sign out of  **LON-CL1**
 
-11. On  **LON-DC1**, verify that the  **Profiles** and **Redirected** folders are no longer empty. The **Profiles** folder contains the Ada roaming user profile (Ada.V6), whereas the **Redirected** folder contains Ada Russell’s ** **redirected  **Documents** folder.
+11. On  **LON-DC1**, verify that the  **Profiles** and **Redirected** folders are no longer empty. The **Profiles** folder contains the Ada roaming user profile (Ada.V6), whereas the **Redirected** folder contains Ada Russell’s redirected  **Documents** folder.
 
-12. Sign in to  **LON-CL2** as **Adatum\Ada**.
+12. Sign in to  **LON-CL2** as **Adatum\\Ada**.
 
 13. Verify that the  **Presentations** folder and the **Local Disk (C)** shortcut are on the desktop.
 
 14. Verify that you can access files transparently in the  **Documents** folder that you created on **LON-CL1**. Open the file with your name in  **Notepad**, and then verify that it contains today’s date.
+
 >  **Note:** Remember that you added the date and saved the file on **LON-CL1** while you did not have network connectivity.
+
 15. Sign out of  **LON-CL2**.
 
 
@@ -150,7 +151,7 @@ The main tasks for this exercise are as follows:
 
 3. Switch to the Group Policy Management Console.
 
-4. In  **Default Domain Policy**, enable the  **Computer Configuration\Policies\Administrative Templates\System\User Profiles\Download roaming profiles on primary computers only** setting and the **User Configuration\Policies\Administrative Templates\System\Folder Redirection\Redirect folders on primary computers only** setting.
+4. In  **Default Domain Policy**, enable the  **Computer Configuration\\Policies\\Administrative Templates\\System\\User Profiles\\Download roaming profiles on primary computers only** setting and the **User Configuration\\Policies\\Administrative Templates\\System\\Folder Redirection\\Redirect folders on primary computers only** setting.
 
 5. On  **LON-CL4**, add  **LON-CL4** to the **Adatum.com** domain, and then use **Administrator** and **Pa55w.rd** as required credentials. Restart as required.
 
@@ -158,14 +159,16 @@ The main tasks for this exercise are as follows:
 
 #### Task 6: Test the primary computer setting
   
-1. Sign in to  **LON-CL4** as **Adatum\Ada** with the password **Pa55w.rd**, ** **and then verify that the  **Presentations** folder and the **Local Disk (C)** shortcut are not on the desktop. Additionally, verify in **Notepad** that the file with your name is not available in the **Documents** folder. Sign out of **LON-CL4**. 
+1. Sign in to  **LON-CL4** as **Adatum\\Ada** with the password **Pa55w.rd**, ** **and then verify that the  **Presentations** folder and the **Local Disk (C)** shortcut are not on the desktop. Additionally, verify in **Notepad** that the file with your name is not available in the **Documents** folder. Sign out of **LON-CL4**. 
 
 2. On  **LON-DC1**, edit the value of the  **msDS-PrimaryComputer** attribute of **Ada Russell** and replace **LON-CL2** with **LON-CL4**.
 
-3. Sign in to  **LON-CL4** as **Adatum\Ada** with the password **Pa55w.rd**, and then verify that the  **Presentations** folder and the **Local Disk (C:)** shortcut are on the desktop.
+3. Sign in to  **LON-CL4** as **Adatum\\Ada** with the password **Pa55w.rd**, and then verify that the  **Presentations** folder and the **Local Disk (C:)** shortcut are on the desktop.
 
 4. Verify in  **Notepad** that the file with your name is available in the **Documents** folder. Because you configured **LON-CL4** as Ada Russell’s primary computer, redirected folders are available.
+
 >  **Note:** After you first sign in, the **Documents** folder is empty because the **Folder Redirection** GPO did not apply at first sign-in. Sign out and sign in as **Ada Russell** with the password **Pa55w.rd**, and then repeat the previous step.
+
 5. Revert the  **20697-2C-LON-CL4** virtual machine.
 
 
@@ -206,20 +209,20 @@ After you perform initial configuration, you plan to demonstrate how UE-V can sy
 
 #### Task 2: Configure UE-V Group Policy settings
   
-1. On  **LON-DC1**, use the GPMC to create a Group Policy named  **UE-V**, ** **and then link it to the  **Adatum.com** domain.
+1. On  **LON-DC1**, use the GPMC to create a Group Policy named  **UE-V**, and then link it to the  **Adatum.com** domain.
 
-2. In the  **UE-V** Group Policy, under **Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft User Experience Virtualization**, configure the following policies:
+2. In the  **UE-V** Group Policy, under **Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Microsoft User Experience Virtualization**, configure the following policies:
 
 
   - Enable the  **Enable UEV** setting.
 
-  - Enable the  **Settings template catalog path** setting and configure it to point to **\\LON-DC1\UEVTemplates**.
+  - Enable the  **Settings template catalog path** setting and configure it to point to **\\\\LON-DC1\\UEVTemplates**.
 
 
-3. In the  **UE-V** Group Policy, under **User Configuration\Policies\Administrative Templates\Windows Components\Microsoft User Experience Virtualization**, configure the following policies:
+3. In the  **UE-V** Group Policy, under **User Configuration\\Policies\\Administrative Templates\\Windows Components\\Microsoft User Experience Virtualization**, configure the following policies:
 
 
-  - Enable the  **Settings storage path** setting and configure it to point to **\\LON-DC1\UEVData\%username%**
+  - Enable the  **Settings storage path** setting and configure it to point to **\\\\LON-DC1\\UEVData\\%username%**
 
   - Enable  **Synchronize Windows settings** setting and select **Roaming Credentials** (all five checkboxes should be selected)
 
@@ -227,7 +230,7 @@ After you perform initial configuration, you plan to demonstrate how UE-V can sy
 
 #### Task 3: Enable UE-V, and then verify the effective settings
   
-1. Sign in to  **LON-CL1** as **Adatum\Administrator** with the password **Pa55w.rd**.
+1. Sign in to  **LON-CL1** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
 2. Verify the UE-V status by running the  **Get-UevStatus** cmdlet.
 
@@ -235,30 +238,35 @@ After you perform initial configuration, you plan to demonstrate how UE-V can sy
 
 4. Use the  **Get-UevTemplate** cmdlet to verify that no settings location template is registered by default.
 
-5. Use the  **Register-UevTemplate** cmdlet to register all the XML templates in the **C:\ProgramData\Microsoft\UEV\InboxTemplates** folder.
+5. Use the  **Register-UevTemplate** cmdlet to register all the XML templates in the **C:\\ProgramData\\Microsoft\\UEV\\InboxTemplates** folder.
 
 6. Use the  **Get-UevTemplate** cmdlet to verify that several templates are now registered.
 
 7. Restart  **LON-CL1**.
 
-8. Sign in to  **LON-CL2** as **Adatum\Administrator** with the password **Pa55w.rd** and run the **C:\Labfiles\Mod04\ConfigureUEV.ps1** script. This script enables UE-V, registers default templates, and then restarts the computer.
+8. Sign in to  **LON-CL2** as **Adatum\\Administrator** with the password **Pa55w.rd** and run the **C:\\Labfiles\\Mod04\\ConfigureUEV.ps1** script. This script enables UE-V, registers default templates, and then restarts the computer.
 
 
 
 #### Task 4: Configure UE-V SyncMethod
   
-1. Sign in to  **LON-CL1** and ** LON-CL2** as **Adatum\Administrator** with the password **Pa55w.rd**.
+1. Sign in to  **LON-CL1** and **LON-CL2** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
 2. On  **LON-CL1**, open PowerShell and use  **Get-UevConfiguration** to view the current UE-V configuration.
+
 >  **Note:** Notice that values for **SettingsStoragePath** and **SettingsTemplateCatalogPath** are configured as you set them in Group Policy.
+
 > Also notice that  **SyncMethod** is set to **SyncProvider**. This means that UE-V is using the local setting cache, which is synced with the shared network folder every 30 minutes.
+
 3. Use  **Get-Command** cmdlet to view all available cmdlets in the UEV Windows PowerShell module.
 
 4. Start Notepad, and then in Notepad, set the font to  **Verdana** size **48**.
 
 5. On  **LON-CL2**, verify that Notepad is still using the default font and not the font that you configured on  **LON-CL1**.
+
 >  **Note:** UE-V uses the local settings cache by default. Therefore, changes from **LON-CL1** will not be used on **LON-CL2** yet.
-6. On LON-CL2, run ** Set-UevConfiguration** with the **SyncMethod None** parameter ** **to configure UE-V to read settings directly from the network.
+
+6. On LON-CL2, run **Set-UevConfiguration** with the **SyncMethod None** parameter to configure UE-V to read settings directly from the network.
 
 7. Verify that Notepad is using the Verdana size 48 font that you configured on  **LON-CL1**.
 
@@ -271,37 +279,44 @@ After you perform initial configuration, you plan to demonstrate how UE-V can sy
 >  **Note:** You typically would configure **SyncMethod** by using Group Policy. In this lab, you configured it manually to see the difference between UE-V using local settings cache and reading settings directly from the network share.
 
 
+
 #### Task 5: Use UE-V synchronization
   
 1. On  **LON-CL2**, run WordPad, and verify that  **Ruler** and **Status bar** on the **View** tab are selected by default. Clear both check boxes and then close WordPad.
 
-2. On the desktop, create a shortcut to  **Local Disk (C:).**
+2. On the desktop, create a shortcut to  **Local Disk (C:)**.
 
 3. In Notepad, type your name, save the file in the  **Documents** folder, and then close Notepad.
 
 4. Use the  **Certificates** console to request the user certificate.
 
-5. Add a network printer, which is available at the following UNC path:  **\\LON-DC1\Printer1**.
+5. Add a network printer, which is available at the following UNC path:  **\\\\LON-DC1\\Printer1**.
 
-6. On  **LON-DC1**, verify that the  **C:\UEVdata** folder has a subfolder named **Administrator**. 
+6. On  **LON-DC1**, verify that the  **C:\\UEVdata** folder has a subfolder named **Administrator**. 
 
 7. Configure  **File Explorer** to show hidden items, and then verify that the **Administrator** folder contains a **SettingsPackages** subfolder.
 
 8. Verify that the  **SettingsPackages** folder contains multiple subfolders for the applications and Windows settings that UE-V syncs.
+
 >  **Note:** The **SettingsPackages** folder includes the **MicrosoftWordpad6** subfolder, because **Wordpad** stores its settings as soon as you close the app.
+
 9. On  **LON-CL1**, in WordPad, verify that the  **Ruler** and **Status bar** check boxes are not selected, which is not the default configuration, but it is exactly as you configured it on **LON-CL2**. 
 
-10. Sign out of  **LON-CL1** and ** LON-CL2**, and then sign in to  **LON-CL1** as **Adatum\Administrator** with the password **Pa55w.rd**.
+10. Sign out of  **LON-CL1** and **LON-CL2**, and then sign in to  **LON-CL1** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
 11. On  **LON-CL1**, verify that the shortcut to  **Local Disk (C:)** is not present on the desktop.
+
 >  **Note:** UE-V does not sync desktop contents. To do so, you should use **Folder Redirection** or roaming user profiles. The **Folder Redirection** policy that you created earlier does not apply to the Administrator because the Administrator is not in the **Marketing** OU.
+
 12. Use the  **Certificates** console to verify that **Administrator** on **LON-CL1** currently does not have any certificate.
+
 >  **Note:** UE-V syncs certificates when a user signs out for the second time.
+
 13. Sign out of  **LON-CL1**.
 
-14. Sign in to  **LON-CL2** as **Adatum\Administrator** with the password **Pa55w.rd**, and then immediately sign out.
+14. Sign in to  **LON-CL2** as **Adatum\\Administrator** with the password **Pa55w.rd**, and then immediately sign out.
 
-15. Sign in to  **LON-CL1** as **Adatum\Administrator** with the password **Pa55w.rd**.
+15. Sign in to  **LON-CL1** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
 16. Use the  **Certificates** console to verify that **Administrator** now has a certificate, which was synced by UE-V from **LON-CL2**.
 
@@ -311,29 +326,29 @@ After you perform initial configuration, you plan to demonstrate how UE-V can sy
 
 #### Task 6: Create and use custom UE-V template
   
-1. On  **LON-CL1**, run the Microsoft User Experience Virtualization Generator to create a settings location template ** **for the following program:  **C:\Program files (x86)\Microsoft\Remote Desktop Connection Manager\RDCMan.exe**.
+1. On  **LON-CL1**, run the Microsoft User Experience Virtualization Generator to create a settings location template for the following program:  **C:\\Program files (x86)\\Microsoft\\Remote Desktop Connection Manager\\RDCMan.exe**.
 
-2. In  **Remote Desktop Connection Manager**, modify one of the available options, ** **and then close  **Remote Desktop Connection Manager**.
+2. In  **Remote Desktop Connection Manager**, modify one of the available options, and then close  **Remote Desktop Connection Manager**.
 
-3. Include a nonstandard file location that includes Remote Desktop Connection Manager in the settings location template, and then save the settings location template to  **\\LON-DC1\UEVTemplates\RDCMan.xml**.
+3. Include a nonstandard file location that includes Remote Desktop Connection Manager in the settings location template, and then save the settings location template to  **\\\\LON-DC1\\UEVTemplates\\RDCMan.xml**.
 
 4. On  **LON-CL1**, use the  **Get-UevTemplate** cmdlet to verify that no settings location template that contains the string “rdc” is registered.
 
-5. Use the  **Register-UevTemplate** cmdlet to register the **\\LON-DC1\UEVTemplates\RDCMan.xml** settings location template.
+5. Use the  **Register-UevTemplate** cmdlet to register the **\\\\LON-DC1\\UEVTemplates\\RDCMan.xml** settings location template.
 
 6. Use the  **Get-UevTemplate** cmdlet to verify that the **Remote-Desktop-RDCMan-v-2-7** settings location template is registered.
 
-7. Sign in to  **LON-CL2** as **Adatum\Administrator**, and then use  **Pa55w.rd** as the password.
+7. Sign in to  **LON-CL2** as **Adatum\\Administrator**, and then use  **Pa55w.rd** as the password.
 
-8. Use the  **Register-UevTemplate** cmdlet to register the **\\LON-DC1\UEVTemplates\RDCMan.xml** settings location template.
+8. Use the  **Register-UevTemplate** cmdlet to register the **\\\\LON-DC1\\UEVTemplates\\RDCMan.xml** settings location template.
 
-9. On  **LON-CL1**, run  **Remote Desktop Connection Manager**, ** **configure the  **Auto save interval** to **3 minute(s)**, and then close Remote Desktop Connection Manager.
+9. On  **LON-CL1**, run  **Remote Desktop Connection Manager**, configure the  **Auto save interval** to **3 minute(s)**, and then close Remote Desktop Connection Manager.
 
-10. On  **LON-CL2**, run  **Remote Desktop Connection Manager**, verify that the  **Auto save interval** is selected and is configured to **3 minute(s)**, ** **and then close  **Remote Desktop Connection Manager**.
+10. On  **LON-CL2**, run  **Remote Desktop Connection Manager**, verify that the  **Auto save interval** is selected and is configured to **3 minute(s)**, and then close  **Remote Desktop Connection Manager**.
 
 11. Use the  **Restore-UevUserSetting** cmdlet to revert Remote Desktop Connection Manager settings to the initial values.
 
-12. In  **Remote Desktop Connection Manager**, verify that ** Auto save interval** is not enabled, which is its initial state.
+12. In  **Remote Desktop Connection Manager**, verify that **Auto save interval** is not enabled, which is its initial state.
 
 
 >  **Result**: After completing this exercise, you should have successfully implemented and configured UE-V for syncing apps and Windows settings.
@@ -361,13 +376,16 @@ You are preparing the environment for the demonstration. You plan to enable Ente
 
 #### Task 1: Enable Enterprise State Roaming
   
-1. On  **LON-DC1**, use Internet Explorer in InPrivate Browsing mode, navigate to the Azure portal at  **https://portal.azure.com**, ** **and then sign in by using the Microsoft account credentials that you created in the lab in module 3.
->  **Note:** If you followed the suggestion in the lab in Module 3, you created a Microsoft account in the format **&lt;YourInitials&gt;MMDDYY@outlook.com** and used **Pa55w.rd!** as the password. For example, if your name is Don Funk and you created Microsoft account on November 18, 2017, your account should be DF111817@outlook.com.
+1. On  **LON-DC1**, use Internet Explorer in InPrivate Browsing mode, navigate to the Azure portal at [**https://portal.azure.com**](https://portal.azure.com), and then sign in by using the Microsoft account credentials that you created in the lab in module 3.
+
+>  **Note:** If you followed the suggestion in the lab in Module 3, you created a Microsoft account in the format **_&lt;YourInitials&gt;&lt;MMDDYY&gt;_@outlook.com** and used **Pa55w.rd!** as the password. For example, if your name is Don Funk and you created Microsoft account on November 18, 2017, your account should be DF111817@outlook.com.
+
 2. In the Azure Portal, in the  **Azure Active Directory** pane, select **Devices**, and then note the devices that are currently in Azure AD.
 
 3. Use the  **Devices Settings** option to allow the user named **Aidan Norman** to sync settings and app data across devices. Make note of Aidan’s account, because you will need it in the next task.
 
 >  **Note:** By performing this task, you enabled Enterprise State Roaming for Aidan Norman.
+
 
 
 #### Task 2: Add a computer to Azure AD
@@ -376,11 +394,13 @@ You are preparing the environment for the demonstration. You plan to enable Ente
 
 2. Accept the default options on out-of-box experience (OOBE) pages.
 
-3. On the  **Sign in with Microsoft** page, in the text box, type **Aidan@&lt;YourInitialsDDMMYY&gt;outlook.onmicrosoft.com** and on the next page specify **Pa55w.rd** as the password.
->  **Note:** If you followed the suggestion in Module 3, you created a Microsoft account in the format **&lt;YourInitials&gt;MMDDYY@outlook.com**. For example, if your name is Don Funk and you created Microsoft account on November 18, 2017, your account should be DF111817@outlook.com. In that case, you should type  **Aidan@DF111817outlook.onmicrosoft.com** as the account.
-4. On  **LON-CL3**, sign in as the same user,  **Aidan@&lt;YourInitialsDDMMYY&gt;outlook.onmicrosoft.com**, use  **Pa55w.rd** as the password, and skip the creation of the personal identifitication number (PIN).
+3. On the  **Sign in with Microsoft** page, in the text box, type **Aidan@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** and on the next page specify **Pa55w.rd** as the password.
 
-5. Open the  **Sync your settings** page, and then verify that **Sync Settings** is **On**. Also verify that all individual sync settings are turned on and that you are using the device as Aidan@ _&lt;YourInitialsDDMMYY&gt;_outlook.onmicrosoft.com.
+>  **Note:** If you followed the suggestion in Module 3, you created a Microsoft account in the format **_&lt;YourInitials&gt;&lt;MMDDYY&gt;_@outlook.com**. For example, if your name is Don Funk and you created Microsoft account on November 18, 2017, your account should be DF111817@outlook.com. In that case, you should type  **Aidan@DF111817outlook.onmicrosoft.com** as the account.
+
+4. On  **LON-CL3**, sign in as the same user,  **Aidan@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**, use  **Pa55w.rd** as the password, and skip the creation of the personal identifitication number (PIN).
+
+5. Open the  **Sync your settings** page, and then verify that **Sync Settings** is **On**. Also verify that all individual sync settings are turned on and that you are using the device as Aidan@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com.
 
 6. On  **LON-CL5**, skip the creation of the PIN, and then wait until the user is signed in.
 
@@ -390,10 +410,12 @@ You are preparing the environment for the demonstration. You plan to enable Ente
 
 #### Task 3: View device properties and sync status
   
-1. On  **LON-CL5**, in Internet Explorer, add the URL  **https://www.microsoft.com/learning** to favorites.
+1. On  **LON-CL5**, in Internet Explorer, add the URL  [**https://www.microsoft.com/learning**](https://www.microsoft.com/learning) to favorites.
 
 2. On  **LON-CL3**, verify whether the URL that you added to favorites in Internet Explorer on  **LON-CL5** has already synced.
+
 >  **Note:** Enterprise State Roaming typically syncs settings fairly quickly. However, if the setting is not yet there, you might need to wait a bit longer.
+
 3. On  **LON-DC1**, use Internet Explorer to verify that the device whose name starts with  **DESKTOP-** was added to Azure AD in this exercise.
 
 4. Use the device view, which shows all the devices that  **Aidan Norman** owns.
@@ -413,11 +435,12 @@ You are preparing the environment for the demonstration. You plan to enable Ente
 4. Use the  **GPMC** to delete the **UE-V** Group Policy that is linked to the Adatum.com domain and the **Folder Redirection** GPO that is linked to the **Marketing** OU.
 
 5. Create a checkpoint of  **LON-CL5**, and name it  **After Lab 4A**. You can create the checkpoint by performing the following steps:
-In the  **20697-2A-LON-CL5** window, select **Action**, ** **and then select  **Checkpoint**.
 
-In the  **Checkpoint name** dialog box, type **After Lab 4A**, select  **Yes**, and then select  **OK**. 
+-In the  **20697-2A-LON-CL5** window, select **Action**, ** **and then select  **Checkpoint**.
 
-6. Revert the  **LON-CL1**,  **LON-CL2**, and  **LON-CL5** virtual machines. ** _Do not revert LON-DC1_**! You can revert the virtual machines by performing the following steps:
+-In the  **Checkpoint name** dialog box, type **After Lab 4A**, select  **Yes**, and then select  **OK**. 
+
+6. Revert the  **LON-CL1**,  **LON-CL2**, and  **LON-CL5** virtual machines. **_Do not revert LON-DC1_!** You can revert the virtual machines by performing the following steps:
 On the host computer, start Hyper-V Manager.
 
 In the  **Virtual Machines** list, right-click **20697-2C-LON-CL1**, and then select  **Revert**.
@@ -430,7 +453,9 @@ Repeat steps b and c for  **20697-2C-LON-CL2** and **20697-2C-LON-CL5**.
 
 8. Shut down  **MT17B-WS2016-NAT**.
 
->  **Note:** Do not revert **LON-DC1**.  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.
+    >  **Note:** Do not revert **LON-DC1**.  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have successfully configured Enterprise State Roaming in Azure AD, joined a Windows 10 device to Azure AD, and performed a sync.
 
@@ -449,6 +474,7 @@ Which tool can you use to create a UE-V settings location template?
 
 
 
+
 # Lab B: Migrating a user state by using USMT
   
 ### Scenario
@@ -461,7 +487,7 @@ You plan to replace her computer. You have already installed new computer and jo
 
 - Content of  **Public Documents** folder.
 
-- Content of  **C:\Projects** folder.
+- Content of  **C:\\Projects** folder.
 
 
  You should not migrate the following:
@@ -475,7 +501,7 @@ You plan to replace her computer. You have already installed new computer and jo
 - Settings for other domain users.
 
 
- You should use USMT to perform the migration. USMT is available on the  **\\LON-DC1\USMT** shared folder, and you can use **\\LON-DC1\MigStore** as a location to store the data during the migration. The data store should be compressed to minimize space. Because there is no confidential information, you don’t need to encrypt the migration store.
+ You should use USMT to perform the migration. USMT is available on the  **\\\\LON-DC1\\USMT** shared folder, and you can use **\\\\LON-DC1\\MigStore** as a location to store the data during the migration. The data store should be compressed to minimize space. Because there is no confidential information, you don’t need to encrypt the migration store.
 
 
 ### Objectives
@@ -491,10 +517,11 @@ You plan to replace her computer. You have already installed new computer and jo
   
  Estimated Time: 20 minutes
 
-Virtual machines:  **20697-2C-LON-DC1**, ** 20697-2C-LON-CL1**, and ** 20697-2C-LON-CL2**
+Virtual machines:  **20697-2C-LON-DC1**, **20697-2C-LON-CL1**, and **20697-2C-LON-CL2**
+
 >  **Note:** Start the **LON-CL1** and **LON-CL2** virtual machines, but do not sign in to them. **LON-DC1** should be running from the previous lab.
 
-  All three virtual machines should be running. You do not need to sign in to any of them. **LON-DC1** should be running from the previous lab, so you do not need to start it. Start **LON-CL1** and ** LON-CL2**.
+All three virtual machines should be running. You do not need to sign in to any of them. **LON-DC1** should be running from the previous lab, so you do not need to start it. Start **LON-CL1** and **LON-CL2**.
 
 
 ## Exercise 1: Capture the user state on the source computer
@@ -515,22 +542,23 @@ Based on the guidance, you will modify the  **Config.xml** file to exclude **Pub
 
 #### Task 1: Create a custom XML migration file
   
-1. Sign in to  **LON-CL2** as **Adatum\Vera** with the password **Pa55w.rd**.
+1. Sign in to  **LON-CL2** as **Adatum\\Vera** with the password **Pa55w.rd**.
 
 2. Verify that Vera has a black desktop and the following custom configuration:
- **This PC** and **Vera Pace** folders are on the desktop
 
-Calculator and Weather apps are pinned to the taskbar
+- **This PC** and **Vera Pace** folders are on the desktop
 
-Store and Mail apps are not pinned to the taskbar
+- Calculator and Weather apps are pinned to the taskbar
+
+- Store and Mail apps are not pinned to the taskbar
 
 3. Create a new text document on the desktop.
 
-4. Create a new text document named  **Vera’s Public Documents** in the **C:\Users\Public\Public Documents** folder.
+4. Create a new text document named  **Vera’s Public Documents** in the **C:\\Users\\Public\\Public Documents** folder.
 
-5. Create a new text document named  **Vera’s Public Music** in the **C:\Users\Public\Public Music** folder.
+5. Create a new text document named  **Vera’s Public Music** in the **C:\\Users\\Public\\Public Music** folder.
 
-6. Sign out and then sign in to  **LON-CL2** as **Adatum\Administrator** with the password **Pa55w.rd**.
+6. Sign out and then sign in to  **LON-CL2** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
 7. In Windows PowerShell, map a network drive on LON-DC1 by using the following command:
 
@@ -538,7 +566,7 @@ Store and Mail apps are not pinned to the taskbar
   Net Use F: \\LON-DC1\USMT
   ```
 
-8. Change to drive F, and then create a  **Config.xml** file by using the following command:
+8. Change to drive F:, and then create a  **Config.xml** file by using the following command:
 
   ```
   scanstate /i:migapp.xml /i:miguser.xml /genconfig:Config.xml
@@ -556,15 +584,15 @@ Store and Mail apps are not pinned to the taskbar
   - Security-Malware-Windows-Defender
 
 
-11. Use Notepad to edit folders.xml, ** **and replace the string “ _Foldername_” with  **Projects** to migrate the C:\Projects folder and all of its content. The entire line should be similar to the following:
+11. Use Notepad to edit folders.xml, ** **and replace the string “ _Foldername_” with  **Projects** to migrate the C:\\Projects folder and all of its content. The entire line should be similar to the following:
 
   ```
-  &lt;pattern type= “File”&gt;C:\Projects\* [*]&lt;/pattern&gt;
+  <pattern type= “File”>C:\Projects\* [*]</pattern>
   ```
 
 12. Verify that a  **Projects** folder is on disk C and that it contains two files, named **Project1.txt** and **Project2.txt**.
 
-13. Create a new text document that you name by using your name in the  **C:\Projects** folder.
+13. Create a new text document that you name by using your name in the  **C:\\Projects** folder.
 
 
 
@@ -572,7 +600,7 @@ Store and Mail apps are not pinned to the taskbar
   
 1. On  **LON-CL2**, verify that a local user named LocalAdmin exists.
 
-2. On  **LON-CL2**, verify that the ** \\LON-DC1\MigStore** shared folder is empty.
+2. On  **LON-CL2**, verify that the **\\\\LON-DC1\\MigStore** shared folder is empty.
 
 3. Capture user state by using the following command:
 
@@ -580,7 +608,7 @@ Store and Mail apps are not pinned to the taskbar
   F:\Scanstate \\LON-DC1\MigStore /i:migapp.xml /i:miguser.xml /i:folders.xml /config:Config.xml /ue:*\* /ui:adatum\vera /o
   ```
 
-4. Verify that the  **\\LON-DC1\MigStore** shared folder stores the **Usmt.mig** captured user state.
+4. Verify that the  **\\\\LON-DC1\\MigStore** shared folder stores the **Usmt.mig** captured user state.
 
 
 >  **Result**: After completing this exercise, you should have created and customized XML files to use with the USMT.
@@ -606,27 +634,27 @@ You will use the Loadstate tool to restore Vera’s settings to her new computer
 
 #### Task 1: Restore the user state
   
-1. Sign in to  **LON-CL1** as **Adatum\Administrator** with the password **Pa55w.rd**.
+1. Sign in to  **LON-CL1** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
-2. On  **LON-CL1**, verify that  **C:\Users** does not contain a subfolder named **Vera**.
+2. On  **LON-CL1**, verify that  **C:\\Users** does not contain a subfolder named **Vera**.
 
 3. Verify that there is no  **Projects** folder on drive C.
 
 4. Verify that no local user named  **LocalAdmin** is on **LON-CL1**. 
 
-5. Open Windows PowerShell and map drive F to  **\\LON-DC1\USMT** by using the following command:
+5. Open Windows PowerShell and map drive F to  **\\\\LON-DC1\\USMT** by using the following command:
 
   ```
   Net Use F: \\LON-DC1\USMT
   ```
 
-6. Switch to drive F, and then restore the user state on the destination computer by using the following command:
+6. Switch to drive F:, and then restore the user state on the destination computer by using the following command:
 
   ```
   F:\Loadstate \\LON-DC1\MigStore /i:migapp.xml /i:miguser.xml /i:folders.xml /c
   ```
 
-7. Verify that the  **C:\Users** folder contains a subfolder named Vera.
+7. Verify that the  **C:\\Users** folder contains a subfolder named Vera.
 
 8. Verify that there is no local user named  **LocalAdmin** on **LON-CL1**, as this user was excluded from the migration.
 
@@ -636,29 +664,29 @@ You will use the Loadstate tool to restore Vera’s settings to her new computer
 
 #### Task 2: Verify migration of user settings
   
-1. Sign in to  **LON-CL1** as **Adatum\Vera** with the password **Pa55w.rd**.
+1. Sign in to  **LON-CL1** as **Adatum\\Vera** with the password **Pa55w.rd**.
 
 2. Verify that Vera has a black desktop, file with your name on the desktop and the same customizations as on  **LON-CL2**:
 
 
-  -  **This PC** and **Vera Pace** folders are on the desktop
+  - **This PC** and **Vera Pace** folders are on the desktop
 
   - Calculator and Weather apps are pinned to the taskbar
 
   - Store and Mail apps are not pinned to the taskbar
 
 
-1. Verify that the ** C:\Projects** folder with all its content, including the file with your name, has migrated successfully.
+3. Verify that the **C:\\Projects** folder with all its content, including the file with your name, has migrated successfully.
 
-2. Verify that file  **Vera’s Public Documents** is in the **Public Documents** folder.
+4. Verify that file  **Vera’s Public Documents** is in the **Public Documents** folder.
 
-3. Verify that the folder  **Public Music** is empty, as its content was excluded from the migration.
+5. Verify that the folder  **Public Music** is empty, as its content was excluded from the migration.
 
 
 
 #### Task 3: Prepare for the next module
   
- When you are finished with the lab, revert the  **LON-CL1** and ** LON-CL2** virtual machines to their initial state.
+ When you are finished with the lab, revert the  **LON-CL1** and **LON-CL2** virtual machines to their initial state.
 
 1. On the host computer, start  **Hyper-V Manager**.
 
@@ -668,7 +696,9 @@ You will use the Loadstate tool to restore Vera’s settings to her new computer
 
 4. Repeat steps 2 and 3 for  **20697-2C-LON-CL2**.
 
->  **Note:** Do not revert **LON-DC1**!  **LON-DC1** is synchronizing on-premises AD DS with Azure AD. You can shut down LON-DC1.
+    >  **Note:** Do not revert **LON-DC1**!  **LON-DC1** is synchronizing on-premises AD DS with Azure AD. You can shut down LON-DC1.
+
+<!-- -->
 
 >  **Result**: After performing this exercise, you will restore user state on destination computer.
 

--- a/Instructions/206972C_LAB_05.md
+++ b/Instructions/206972C_LAB_05.md
@@ -1,4 +1,4 @@
-# Module 5: Managing desktop and application settings by using Group Policy
+﻿# Module 5: Managing desktop and application settings by using Group Policy
 # Lab: Configuring Group Policy policies and Group Policy preferences
   
 ### Scenario
@@ -14,13 +14,14 @@
   
  Estimated Time: 50 minutes
 
-Virtual machines:  **20697-2C-LON-DC1**, ** 20697-2C-LON-CL1**, ** **and ** 20697-2C-LON-CL2**
+Virtual machines:  **20697-2C-LON-DC1**, **20697-2C-LON-CL1**, and **20697-2C-LON-CL2**
 
- Usernames:  **Adatum\Administrator** and **Adatum\Beth**
+ - Usernames:  **Adatum\\Administrator** and **Adatum\\Beth**
 
- Password:  **Pa55w.rd**
+ - Password:  **Pa55w.rd**
 
- For this lab, you will use the available virtual machine environment. ** **Before you begin the lab, you must complete the following steps:
+
+ For this lab, you will use the available virtual machine environment. Before you begin the lab, you must complete the following steps:
 
 1. On the host computer, start  **Hyper-V Manager**.
 
@@ -30,17 +31,15 @@ Virtual machines:  **20697-2C-LON-DC1**, ** 20697-2C-LON-CL1**, ** **and ** 206
 
 4. Sign in by using the following credentials: 
 
-
   - User name:  **Administrator**
 
   - Password:  **Pa55w.rd**
 
   - Domain:  **Adatum**
 
+5. Repeat steps 2 to 4 for  **20697-2C-LON-CL1.**
 
-3. Repeat steps 2 to 4 for  **20697-2C-LON-CL1.**
-
-4. Repeat steps 2 and 3 for ** 20697-2C-LON-CL2**.
+6. Repeat steps 2 and 3 for **20697-2C-LON-CL2**.
 
 
 
@@ -66,23 +65,23 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Preparing the environment
   
-1. On  **LON-DC1**, run the  **E:\Labfiles\Mod05\Mod05-Preparation.ps1** script.
+1. On  **LON-DC1**, run the  **E:\\Labfiles\\Mod05\\Mod05-Preparation.ps1** script.
 
-2. Sign in to  **LON-CL2** as **Adatum\Beth** with the password **Pa55w.rd**.
+2. Sign in to  **LON-CL2** as **Adatum\\Beth** with the password **Pa55w.rd**.
 
 3. Verify that  **GPMC** is not available on **LON-CL2**.
 
 4. Verify that there is only one snap-in available that starts with words  **Group Policy**. Also verify that  **Resultant Set of Policy** snap-in is available on **LON-CL2**.
 
-5. Use  **Get-Command *gpo*** cmdlet to verify that only three commands that include string gpo are available and that they are not from GroupPolicy module.
+5. Use  **Get-Command \*gpo\*** cmdlet to verify that only three commands that include string gpo are available, and that they are not from GroupPolicy module.
 
 6. Verify that Beth’s desktop is black.
 
-7. Verify the current Screen Saver configuration. Check that the  **On resume, display logon screen** check box is not selected and not grayed out. Also verify that if you select any screen saver, you can modify value in Wait text box.
+7. Verify the current Screen Saver configuration. Check that the  **On resume, display logon screen** check box is not selected and not grayed out.  Also verify that if you select any screen saver, you can modify value in the **Wait:** text box.
 
 8. On  **LON-CL1**, verify that there are four snap-ins that starts with words  **Group Policy**.
 
-9. Use  **Get-Command *gpo*** cmdlet to list all commands that include the letters **gpo**. This time, the output is longer and many of those commands are from the  **GroupPolicy** Windows PowerShell module.
+9. Use the **Get-Command \*gpo\*** cmdlet to list all commands that include the letters **gpo**. This time, the output is longer and many of those commands are from the  **GroupPolicy** Windows PowerShell module.
 
 10. Verify that the  **Technicians** OU is in the **IT** OU. Also verify that user **Beth Burke** is in the **Technicians** OU.
 
@@ -92,18 +91,17 @@ The main tasks for this exercise are as follows:
 
 #### Task 2: Creating and linking GPOs
   
-1. On  **LON-CL1**, create a GPO named  **Background1**, ** **and then link it to the  **IT** OU.
+1. On  **LON-CL1**, create a GPO named  **Background1**, and then link it to the  **IT** OU.
 
-2. Edit the  **Background1** GPO, and then configure the following settings at **User Configuration\Policies\Administrative Templates\Desktop\Desktop**:
-
+2. Edit the  **Background1** GPO, and then configure the following settings at  
+**User Configuration\\Policies\\Administrative Templates\\Desktop\\Desktop**:
 
   - Desktop Wallpaper:  **Enabled**
 
-  - Wallpaper Name:  **\\LON-DC1\Labfiles\Mod05\img1.jpg**
+  - Wallpaper Name:  **\\\\LON-DC1\\Labfiles\\Mod05\\img1.jpg**
 
-
-3. In the  **Background1** GPO, configure following settings at **User Configuration\Policies\Administrative Templates\Control Panel\Personalize**:
-
+3. In the  **Background1** GPO, configure following settings at:  
+**User Configuration\\Policies\\Administrative Templates\\Control Panel\\Personalize**:
 
   - Screen saver timeout:  **Enabled**
 
@@ -111,26 +109,25 @@ The main tasks for this exercise are as follows:
 
   - Password protect the screensaver:  **Enabled**
 
-
-4. On  **LON-CL2**, sign out and then sign in as  **Adatum\Beth** and use **Pa55w.rd** as the password.
+4. On  **LON-CL2**, sign out and then sign in as  **Adatum\\Beth** and use **Pa55w.rd** as the password.
 
 5. Verify that Beth’s desktop is no longer black and that an image displays instead. This is the image you specified in the  **Background1** GPO.
 
-6. Verify the current Screen Saver configuration. Check that the  **On resume, display logon screen** check box is selected and **Wait** is set to **31 minutes**, which is 1860 seconds. Also verify that both settings are greyed out and you cannot change them, as they were set in a GPO. 
+6. Verify the current Screen Saver configuration. Check that the  **On resume, display logon screen** check box is selected and **Wait** is set to **31 minutes**, which is 1860 seconds.  
+Also verify that both settings are greyed out and you cannot change them, as they were set in a GPO. 
 
 7. On  **LON-CL1**, copy  **Background1** GPO to new GPO and name it **Background2**.
 
-8. In the  **Background2** GPO, configure the following settings at **User Configuration\Policies\Administrative Templates\Desktop\Desktop**:
-
+8. In the  **Background2** GPO, configure the following settings at:  
+**User Configuration\\Policies\\Administrative Templates\\Desktop\\Desktop**:
 
   - Desktop Wallpaper:  **Enabled**
 
-  - Wallpaper Name:  **\\LON-DC1\Labfiles\Mod05\img8.jpg**
+  - Wallpaper Name:  **\\\\LON-DC1\\Labfiles\\Mod05\\img8.jpg**
 
+9. Link  **Background2** GPO to **Technicians** OU.
 
-9. Link  **Background2** GPO to **Technicians** OU **.**
-
-10. On  **LON-CL2**, sign out and then sign in as  **Adatum\Beth** and use **Pa55w.rd** as her password.
+10. On  **LON-CL2**, sign out and then sign in as  **Adatum\\Beth** and use **Pa55w.rd** as her password.
 
 11. Verify that Beth’s background changed and now it is picture of flower, as you set it in Background2 GPO. That GPO is linked to the OU that contains Beth’s account and because of that it has overwritten the settings from the  **Background1** GPO.
 
@@ -146,9 +143,10 @@ The main tasks for this exercise are as follows:
 
 3. Set block inheritance on  **Technicians** OU.
 
-4. Verify how the  **GPMC** shows block inheritance on Technicians OU. Also verify that no GPO applies to Technicians OU.
+4. Verify how the  **GPMC** shows block inheritance on Technicians OU.  
+Also verify that no GPO applies to Technicians OU.
 
-5. On  **LON-CL2**, sign out, and then sign in as  **Adatum\Beth**, ** **and use  **Pa55w.rd** as her password.
+5. On  **LON-CL2**, sign out, and then sign in as  **Adatum\\Beth**, and use  **Pa55w.rd** as her password.
 
 6. Verify that Beth’s background changed to black, because neither the  **Background1** GPO nor the **Background2** GPO apply to her.
 
@@ -158,9 +156,10 @@ The main tasks for this exercise are as follows:
 
 9. Enforce  **Background1** GPO link to IT OU.
 
-10. Verify how the  **GPMC** shows that the **Background1** link is enforced. Also verify that now the **Background1** and **Background2** GPOs apply to the **Technicians** OU and that the **Background1** GPO has a precedence of 1. This is because **Background1** GPO link is enforced.
+10. Verify how the  **GPMC** shows that the **Background1** link is enforced.  
+Also verify that now the **Background1** and **Background2** GPOs apply to the **Technicians** OU and that the **Background1** GPO has a precedence of 1. This is because **Background1** GPO link is enforced.
 
-11. On  **LON-CL2**, sign out and then sign in as  **Adatum\Beth** with the ** **password  **Pa55w.rd**.
+11. On  **LON-CL2**, sign out and then sign in as  **Adatum\\Beth** with the password  **Pa55w.rd**.
 
 12. Verify that after a few seconds, Beth’s background changes back to an image of a running person, which is configured in the  **Background1** GPO.
 
@@ -176,12 +175,19 @@ The main tasks for this exercise are as follows:
 
 4. Open the Group Policy results report of Beth signing to  **LON-CL2** in advanced view.
 
-5. In advanced view, navigate to the  **User Configuration\Administrative Templates\Desktop\Desktop** node.
->  **Note:** Notice that only Control Panel and Desktop nodes are shown under Administrative Templates. This is because you configured GPO settings only in those two nodes.
+5. In advanced view, navigate to the:  
+**User Configuration\\Administrative Templates\\Desktop\\Desktop** node.
+
+>  **Note:** Notice that only Control Panel and Desktop nodes are shown under Administrative Templates.  
+ This is because you configured GPO settings only in those two nodes.
+
 6. View properties of  **Desktop Wallpaper** setting. Verify that properties include three tabs, on which you can view setting that was applied, as well as all GPOs with conflicting setting.
 
-7. Use  **GPMC** to generate a Group Policy modeling report of Tia signing in on a computer that has an account in the **Computers** container. Review other settings that can be configured, but don’t modify defaults.
+7. Use  **GPMC** to generate a Group Policy modeling report of Tia signing in on a computer that has an account in the **Computers** container.  
+Review other settings that can be configured, but don’t modify defaults.
+
 >  **Note:** In the **Group Policy Modeling Wizard**, you can configure many additional settings, which you cannot set when you run the  **Group Policy Results Wizard**. The  **Group Policy Results Wizard** shows what happened in the past and you cannot influence that, whereas the **Group Policy Modeling Wizard** shows what will happen under some assumptions and you can specify those assumptions.
+
 8. In the Group Policy modeling report of Tia signing in to  **Computers**, view the  **User Details** section and verify that no user settings would be applied, because Tia’s account is in the Research OU and neither Background1 nor Background2 GPOs apply to that OU.
 
 
@@ -190,19 +196,23 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-CL1**, use Group Policy Management Editor to verify that administrative templates are currently retrieved from the local computer.
 
-2. Copy the  **C:\Windows\PolicyDefinitions** folder to the ** \\LON-DC1\sysvol\Adatum.com\Policies** folder.
+2. Copy the  **C:\\Windows\\PolicyDefinitions** folder to the **\\\\LON-DC1\\sysvol\\Adatum.com\\Policies** folder.
+
 >  **Note:** You copied a local copy of administrative templates to a domain controller and created central store.
+
 3. Use Group Policy Management Editor to verify that administrative templates are now retrieved from the central store.
 
 4. Verify that GPOs don’t have  **Microsoft Office 2016 (Machine)** node in **Administrative Templates** part of computer policy, but they do have **Microsoft User Experience Virtualization** node under **Windows Components**.
 
-5. Copy content of folder  **E:\Labfiles\Mod05\admx** to ** \\LON-DC1\sysvol\Adatum.com\Policies\PolicyDefinitions** folder.
+5. Copy the contents of folder  **E:\\Labfiles\\Mod05\\admx** to the:  
+**\\\\LON-DC1\\sysvol\\Adatum.com\\Policies\\PolicyDefinitions** folder.
 
 6. Delete  **UserExperienceVirutalization.admx** from the central store.
 
 7. On  **LON-CL1**, verify that GPOs now have  **Microsoft Office 2016 (Machine)** node in **Administrative Templates** part of computer policy, but they do not have **Microsoft User Experience Virtualization** node under **Windows Components**.
 
-8. On LON-DC1, use  **GPMC** to verify that administrative templates are retrieved from the central store. Also verify that GPOs have **Microsoft Office 2016 (Machine)** node in **Administrative Templates** part of computer policy, but they do not have **Microsoft User Experience Virtualization** node under **Windows Components**, because you deleted administrative template from the central store.
+8. On LON-DC1, use  **GPMC** to verify that administrative templates are retrieved from the central store.  
+Also verify that GPOs have **Microsoft Office 2016 (Machine)** node in **Administrative Templates** part of computer policy, but they do not have **Microsoft User Experience Virtualization** node under **Windows Components**, because you deleted administrative template from the central store.
 
 9. Remove central store by deleting the  **PolicyDefinitions** folder in the **SYSVOL** shared folder on LON-DC1.
 
@@ -210,9 +220,12 @@ The main tasks for this exercise are as follows:
 
 11. Verify that GPOs don’t have  **Microsoft Office 2016 (Machine)** node in **Administrative Templates** part of computer policy, but they do have **Microsoft User Experience Virtualization** node under **Windows Components**.
 
->  **Note:** Updates that you performed in central store are not effective, because local copy of administrative templates is used again.
+    >  **Note:** Updates that you performed in central store are not effective, because local copy of administrative templates is used again.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have configured and linked GPOs, modified the GPO processing order, created a central store, and generated an RSoP report.
+
 
 
 ## Exercise 2: Configuring and using Group Policy preferences
@@ -237,25 +250,24 @@ The main tasks for this exercise are as follows:
 
 2. Configure  **Preferences** GPO with following two shortcuts preference settings in the user configuration:
 
+  + First shortcut has following settings:
 
-  - First shortcut has following settings:
+    - Name:  **Shortcut1**
 
-Name:  **Shortcut1**
+    - Location:  **Desktop**
 
-Location:  **Desktop**
-
-Target path:  **C:\**
+    - Target path:  **C:\\**
 
 
-  - Second shortcut has following settings:
+  + Second shortcut has following settings:
 
-Name:  **Shortcut2**
+    - Name:  **Shortcut2**
 
-Location:  **Desktop**
+    - Location:  **Desktop**
 
-Target path:  **C:\**
+    - Target path:  **C:\\**
 
- **Apply once and do not reapply**
+    - **Apply once and do not reapply**
 
 
 3. On  **LON-CL2**, where you are signed in as Beth, verify that currently there is only Recycle Bin icon on the desktop.
@@ -271,14 +283,14 @@ Target path:  **C:\**
 8. On  **LON-CL1**, configure  **Preferences** GPO with the following Internet Settings preference for Internet Explorer 10:
 
 
-  - Home Page:  **http://www.microsoft.com/learning** (enable setting by pressing **F6**)
+  - Home Page:  **https://www.microsoft.com/learning** (enable setting by pressing **F6**)
 
   - Startup:  **Start with tabs from the last session** (disable setting by pressing **F7**)
 
 
 9. On  **LON-CL2**, refresh the GPOs and then verify Internet Explorer configuration for home page and Startup setting. 
 
->  **Note:** The Internet Explorer home page is set to **http://www.microsoft.com/learning**, which you configured in the preference. Because preferences are not enforced, you can modify the setting in Internet Explorer. Startup setting is disabled in Group Policy preference and because of that value that you configured in the preference was not applied.
+>  **Note:** The Internet Explorer home page is set to **https://www.microsoft.com/learning**, which you configured in the preference. Because preferences are not enforced, you can modify the setting in Internet Explorer. Startup setting is disabled in Group Policy preference and because of that value that you configured in the preference was not applied.
 
 
 #### Task 2: Using filtering and item-level targeting
@@ -290,26 +302,35 @@ Target path:  **C:\**
 3. On  **LON-CL1**, use  **GPMC** to modify Security Filtering of **Preferences** GPO by adding Beth Burke and remove **Authenticated Users**. Confirm that only  **Beth Burke** is listed in the **Security Filtering** section.
 
 4. On  **LON-CL2** delete **Shortcut1** on the desktop and then refresh GPOs.
+
 >  **Note:** This time **Shortcut1** does not reappear. Although Beth was listed in the **Security Filtering** section, GPOs are applied in the computers’ security context. Because **LON-CL2**, the computer on which Beth is signed in, does not have at least Read permissions to the  **Preferences** GPO, it cannot apply the settings from the GPO.
-5. On  **LON-CL1**, modify  **Security Filterin**g of  **Preferences** GPO by adding **Domain Computers**.
+
+5. On  **LON-CL1**, modify  **Security Filtering** of the **Preferences** GPO by adding **Domain Computers**.
 
 6. On  **LON-CL2** refresh GPOs. This time Shortcut1 reappears, as **LON-CL2** is member of the **Domain Computers** group and it has permission to read the **Preferences** GPO.
 
-7. On  **LON-CL1**, use  **GPMC** to configure item-level targeting for **Shortcut1** shortcut preference in **Preferences** GPO. Shortcut1 preference should apply only if computer has more than 90 GB free space on system drive and has C:\Folder1 folder.
->  **Note:** Filter condition should read: “free disk space is greater than or equal to 90 GB on the system drive AND the folder C:\Folder1 exists”.
+7. On  **LON-CL1**, use  **GPMC** to configure item-level targeting for **Shortcut1** shortcut preference in **Preferences** GPO. Shortcut1 preference should apply only if computer has more than 90 GB free space on system drive and has C:\\Folder1 folder.
+
+>  **Note:** Filter condition should read:  
+"free disk space is greater than or equal to 90 GB on the system drive AND the folder C:\\Folder1 exists".
+
 8. On  **LON-CL2**, run the following command to create a large file (number 6 is followed by 10 zeroes): 
 
   ```
   Fsutil file createnew file1.txt 60000000000
   ```
 
-9. Verify that disk C has less than 90 GB free space.
+9. Verify that disk C: has less than 90 GB free space.
 
 10. Delete  **Shortcut1** on the desktop and then refresh GPOs.
->  **Note:** **Shortcut1** does not appear, as disk has less than 90GB free space and folder **C:\Folder1** does not exist.
-11. Create folder  **C:\Folder1** and then refresh GPOs.
->  **Note:** Shortcut1 does not appear. Although **C:\Folder1** now exists, disk has still less than 90GB free space.
-12. Delete file named  **file1.txt** that you created earlier. Verify that disk C has now more than 90 GB free space and then refresh GPOs.
+
+>  **Note:** **Shortcut1** does not appear, as disk has less than 90GB free space and folder **C:\\Folder1** does not exist.
+
+11. Create folder  **C:\\Folder1** and then refresh GPOs.
+
+>  **Note:** Shortcut1 does not appear. Although **C:\\Folder1** now exists, disk has still less than 90GB free space.
+
+12. Delete file named  **file1.txt** that you created earlier. Verify that disk C: has now more than 90 GB free space and then refresh GPOs.
 
 >  **Note:** Both conditions from item-level targeting are met and **Shortcut1** now appears on the desktop.
 
@@ -318,7 +339,7 @@ Target path:  **C:\**
   
  When you are finished with the lab, revert  **LON-CL1** and **LON-CL2** virtual machines to their initial state:
 
-1. On  **LON-DC1**, run the  **E:\Labfiles\Mod05\Mod05-Cleanup.ps1** script.
+1. On  **LON-DC1**, run the  **E:\\Labfiles\\Mod05\\Mod05-Cleanup.ps1** script.
 
 2. On the host computer, start  **Hyper-V Manager**.
 
@@ -328,7 +349,10 @@ Target path:  **C:\**
 
 5. Repeat steps 3 and 4 for  **20697-2C-LON-CL2**.
 
->  **Note:** Do not revert **LON-DC1**.  **LON-DC1** is synchronizing on-premises AD DS with Azure AD. You can shut down **LON-DC1**.
+    >  **Note:** **_Do not revert LON-DC1!_**  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.  
+ (You can shut down **LON-DC1**).
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you will configure and apply Group Policy preferences. You will also configure and test GPO filtering and item-level targeting.
 

--- a/Instructions/206972C_LAB_06.md
+++ b/Instructions/206972C_LAB_06.md
@@ -1,4 +1,4 @@
-# Module 6: Managing devices in Microsoft Office 365
+﻿# Module 6: Managing devices in Microsoft Office 365
 # Lab A: Managing devices in Office 365 (Part 1)
   
 ### Scenario
@@ -18,13 +18,15 @@
 
 >  **Note:** The lab steps for this course change often due to Microsoft Azure updates. Microsoft Learning updates the lab steps often, so they are not available in this manual. Your instructor will provide you with the lab documentation.
 
+
+
 ### Lab setup
   
  Estimated Time: 25 minutes
 
-Virtual machines:  **20697-2C-LON-DC1** and ** 20697-2C-LON-CL3**
+Virtual machines:  **20697-2C-LON-DC1** and **20697-2C-LON-CL3**
 
- User name:  **Adatum\Administrator**
+ User name:  **Adatum\\Administrator**
 
  Password:  **Pa55w.rd**
 
@@ -38,11 +40,9 @@ Virtual machines:  **20697-2C-LON-DC1** and ** 20697-2C-LON-CL3**
 
 4. Sign in by using the following credentials: 
 
-
-  - User name:  **Adatum\Administrator**
+  - User name:  **Adatum\\Administrator**
 
   - Password:  **Pa55w.rd**
-
 
 5. Repeat steps 2 and 3 for virtual machines  **20697-2C-LON-CL3**.
 
@@ -52,6 +52,7 @@ Virtual machines:  **20697-2C-LON-DC1** and ** 20697-2C-LON-CL3**
 
 
  To complete the labs in this module successfully, you must first complete all labs in Module 2 and Module 3.
+
 
 
 ## Exercise 1: Obtaining an Office 365 subscription
@@ -70,12 +71,12 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Obtain a trial Office 365 subscription
   
-1. On  **LON-CL3**, open Microsoft Edge, and then navigate to  **https://portal.office.com/AdminPortal**.
+1. On  **LON-CL3**, open Microsoft Edge, and then navigate to  [**https://portal.office.com/AdminPortal**](https://portal.office.com/adminportal/home).
 
 2. Sign in with the following account:
 
 
-- Username:  **GAdmin@&lt;initials&gt;MMDDYY.onmicrosoft.com**
+- Username:  **GAdmin@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password: The password you created in Module 3
 
@@ -105,7 +106,6 @@ The main tasks for this exercise are as follows:
 
 2. Edit the following users, set each user’s location to  **United States**, and then assign the  **Office 365 Enterprise E3** license to each account:
 
-
   - Adam Hobbs
 
   - Abbi Skinner
@@ -116,6 +116,7 @@ The main tasks for this exercise are as follows:
 
 
 >  **Result**: After completing this exercise, you should have successfully obtained a trial subscription to Microsoft Office 365.
+
 
 
 ## Exercise 2: Enabling MDM
@@ -140,7 +141,9 @@ The main tasks for this exercise are as follows:
 
 4. On the  **Need one thing from you** page, accept the default security group and then select **Start setup**. 
 
->  **Note:** The initialization process can take considerable time to complete.
+    >  **Note:** The initialization process can take considerable time to complete.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have successfully enabled MDM in Office 365.
 
@@ -165,7 +168,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Create a DLP
   
-1. On  **LON-CL3**, in Microsoft Edge, open the Security &amp; Compliance center if it is not already open.
+1. On  **LON-CL3**, in Microsoft Edge, open the **Security &amp; Compliance** center if it is not already open.
 
 2. Open the  **Data loss prevention** page.
 
@@ -176,18 +179,18 @@ The main tasks for this exercise are as follows:
   - Locations: All locations
 
   - Sensitive data types:
-U.S. / U.K. Passport Number
-U.S. Bank Account Number
-U.S. Driver’s License Number
-U.S. Social Security Number (SSN)
+    - U.S. / U.K. Passport Number
+    - U.S. Bank Account Number
+    - U.S. Driver’s License Number
+    - U.S. Social Security Number (SSN)
 
   - Detect when this content is shared:
-People outside my organization
+    - People outside my organization
 
   - Overrides:
-Require a business justification.
+    - Require a business justification.
 
-- Override the rule automatically if they report it as a false positive.
+  - Override the rule automatically if they report it as a false positive.
 
 4. On the  **Data loss prevention** page, select the policy **Block external sharing of PII**.
 
@@ -211,7 +214,7 @@ Require a business justification.
   
 1. In Office 365, select the Apps icon, and then open OneDrive for Business
 
-2. Upload the  **EmployeeTravel.xlsx** file from **C:\Labfiles\Mod06\**.
+2. Upload the  **EmployeeTravel.xlsx** file from **C:\\Labfiles\\Mod06\\**.
 
 3. In OneDrive for Business, select the  **EmployeeTravel.xlsx** file.
 
@@ -219,12 +222,14 @@ Require a business justification.
 
 5. In the  **Enter a name or email address** box, type **mary@fabrikam.com**.
 
-6. View the policy tip, and then override the policy, providing the business justification  **Sharing employee information with company travel agent.**
+6. View the policy tip, and then override the policy, providing the business justification:  
+**Sharing employee information with company travel agent.**
 
 7. Close the  **Policy Tip** window, and then attempt to share the file again.
 
->  **Note:** You should see the message “This item contains sensitive information. It can’t be shared with people outside your organization.”
-> If you do not see this message, wait before continuing. It may take up to an hour or more for the policy to be applied.
+>  **Note:** You should see the message:  
+**"This item contains sensitive information. It can’t be shared with people outside your organization."**  
+ If you do not see this message, wait before continuing. It may take up to an hour or more for the policy to be applied.
 
 
 #### Task 3: View alerts in the Security &amp; Compliance center
@@ -236,8 +241,10 @@ Require a business justification.
 3. View the  **DLP policy matches** report.
 
 4. View the  **DLP false positives and overrides** report.
->  **Note:** You should see an entry for the file that you uploaded in both reports, because you chose to override the policy that it matched.
-> It can take several hours for this report to be updated.
+
+>  **Note:** You should see an entry for the file that you uploaded in both reports, because you chose to override the policy that it matched.  
+ It can take several hours for this report to be updated.
+
 5. Expand  **Reports**, and then select  **Dashboard**.
 
 >  **Note:** You should see data in each report, because the file that you uploaded matched a DLP policy.
@@ -270,19 +277,21 @@ Require a business justification.
 
 >  **Note:** The lab steps for this course change often due to Microsoft Azure updates. Microsoft Learning updates the lab steps often, so they are not available in this manual. Your instructor will provide you with the lab documentation.
 
+
 ### Lab setup
   
  Estimated Time: 25 minutes
 
-Virtual machines:  **20697-2C-LON-DC1**, ** 20697-2C-LON-CL3**, and ** 20697-2C-LON-CL4**
+Virtual machines:  **20697-2C-LON-DC1**, **20697-2C-LON-CL3**, and **20697-2C-LON-CL4**
 
- User name:  **Adatum\Administrator**
+ - User name:  **Adatum\\Administrator**
 
- Password:  **Pa55w.rd**
+ - Password:  **Pa55w.rd**
 
- For this lab, you will use the available virtual machine environment. The required virtual machines should be running. You will need to start  **20697-2C-LON-CL4** and then sign in as ** Admin** with the password of ** Pa55w.rd.**
+ For this lab, you will use the available virtual machine environment. The required virtual machines should be running. You will need to start  **20697-2C-LON-CL4** and then sign in as **Admin** with the password of **Pa55w.rd**.
 
  To complete the labs successfully, you must first complete all tasks in Lab A.
+
 
 
 ## Exercise 1: Configuring and testing MDM in Office 365
@@ -309,14 +318,13 @@ The main tasks for this exercise are as follows:
   
 1. On LON-CL3, switch to the  **Office 365 Admincenter**.
 
-2. In the  **Office 365 Admincenter**, create a new group with the following properties:
+2. In the  **Office 365 Admincenter**, create a new **group** with the following properties:
 
+  -  Type: **Security Group**
 
-  -  **Type**: ** Security Group**
+  -  Group name:  **Windows Devices**
 
-  -  **Group name**:  **Windows Devices**
-
-  -  **Members**:  **Adam Hobbs**, ** Abbi Skinner**
+  -  Members:  **Adam Hobbs**, **Abbi Skinner**
 
 
 
@@ -326,22 +334,21 @@ The main tasks for this exercise are as follows:
 
 2. Create a new security policy with the following settings: 
 
-
   - Name:  **Windows devices**
 
   - Description:  **A Datum policies for Windows devices**.
 
-  -  **What requirements do you want to have on devices?** options:
-  **Require a password**:  **Yes**
- **Minimum password length**:  **4**
- **Block access and report violation**
+  -  What requirements do you want to have on devices? options:
+    - Require a password:  **Yes**
+    - Minimum password length:  **4**
+    - **Block access and report violation**
 
-  -  **What else do you want to configure?** options:
- **Block screen capture**
- **Block connection with removable storage**
- **Block Bluetooth connection**
+  -  What else do you want to configure? options:
+    - **Block screen capture**
+    - **Block connection with removable storage**
+    - **Block Bluetooth connection**
 
-3. Choose to apply the policy immediately.
+3. Choose to **apply the policy immediately**.
 
 4. Add the  **Windows Devices** group to the policy, and then create the policy.
 
@@ -353,22 +360,20 @@ The main tasks for this exercise are as follows:
 
 2. In  **Accounts**, select  **Access work or school**, and then select  **Connect**. Use the following information to complete the enrollment: 
 
-
-  -  **Email address**:  **Abbi@your_domain.onmicrosoft.com**
+  -  **Email address**:  **Abbi@*&lt;your_domain&gt;*.onmicrosoft.com**
 
   -  **Password**:  **Pa55w.rd**
 
-
-3. Open the Mail app.
+3. Open the **Mail** app.
 
 4. Add a new account: 
 
-
   -  **Choose an account**:  **Exchange**
 
-  -  **Email address**:  **Abbi@your_domain.onmicrosoft.com**
+  -  **Email address**:  **Abbi@*&lt;your_domain&gt;*.onmicrosoft.com**
 
 >  **Note:** Wait for a few minutes to give the policy time to apply to your device.
+
 
 
 #### Task 4: View managed devices
@@ -391,7 +396,10 @@ The main tasks for this exercise are as follows:
 
 4. Repeat steps 2 and 3 for  **20697-2C-LON-CL4**.
 
->  **Note:** Do not revert **LON-DC1**.  **LON-DC1** is synchronizing on-premises AD DS with Azure AD. You can shut down LON-DC1 and MT17B-WS2016-NAT.
+    >  **Note:** **_Do not revert LON-DC1!_**  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.  
+  (You can shut down **LON-DC1** and **MT17B-WS2016-NAT**.)
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have successfully enrolled devices and ensured that they comply with corporate policies for Office 365 access.
 
@@ -404,6 +412,10 @@ In the lab, you configured a policy to block access to removable storage. To whi
 
 **Question** 
 In the lab, you used groups to decide how to apply policies. If a user has multiple devices and belongs to a group to which a policy is applied, to which devices does the policy apply?
+
+
+
+##
 
 
 

--- a/Instructions/206972C_LAB_07.md
+++ b/Instructions/206972C_LAB_07.md
@@ -1,4 +1,4 @@
-# Module 7: Managing devices by using Microsoft Intune
+﻿# Module 7: Managing devices by using Microsoft Intune
 # Lab A: Implementing Intune
   
 ### Scenario
@@ -18,17 +18,17 @@
 
 - Use the Intune classic portal.
 
->  **Note:** The lab steps for this course change frequently because of updates to Azure. Microsoft Learning frequently updates the lab steps, so they are not available in this manual. Your instructor will provide you with the lab documentation.
+    >  **Note:** The lab steps for this course change frequently because of updates to Azure. Microsoft Learning frequently updates the lab steps, so they are not available in this manual. Your instructor will provide you with the lab documentation.
 
 ### Lab setup
   
  Estimated Time: 45 minutes
 
-Virtual machines:  **20697-2C-LON-DC1**, ** 20697-2C-LON-CL3**, and ** 20697-2C-LON-CL4**
+Virtual machines:  **20697-2C-LON-DC1**, **20697-2C-LON-CL3**, and **20697-2C-LON-CL4**
 
- User name:  **Adatum\Administrator**
+ - User name:  **Adatum\\Administrator**
 
- Password:  **Pa55w.rd**
+ - Password:  **Pa55w.rd**
 
  For this lab, you will use the available virtual machine environment. Before you begin the lab, complete the following steps:
 
@@ -40,15 +40,13 @@ Virtual machines:  **20697-2C-LON-DC1**, ** 20697-2C-LON-CL3**, and ** 20697-2C-
 
 4. Sign in by using the following credentials: 
 
-
-- User name:  **Adatum\Administrator**
+- User name:  **Adatum\\Administrator**
 
 - Password:  **Pa55w.rd**
 
-
 5. Repeat steps 2 and 3 for virtual machines  **20697-2C-LON-CL3** and **20697-2C-LON-CL4**.
 
-6. On  **LON-CL3** and ** LON-CL4**, sign in as  **Admin** with the password **Pa55w.rd**.
+6. On  **LON-CL3** and **LON-CL4**, sign in as  **Admin** with the password **Pa55w.rd**.
 
 7. For Internet access, start  **MT17B-WS2016-NAT**. You do not need to sign in to this VM.
 
@@ -76,20 +74,17 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Assign Microsoft Enterprise Mobility + Security licenses to users
   
-1. On  **LON-CL3**, open Microsoft Edge and navigate to https://portal.office.com/AdminPortal.
+1. On  **LON-CL3**, open Microsoft Edge and navigate to [**https://portal.office.com/AdminPortal**](https://portal.office.com/AdminPortal).
 
 2. Sign in with the following account:
 
-
-- Username:  **GAdmin@initialsMMDDYY.onmicrosoft.com**
+- Username:  **GAdmin@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password: The password you created in Module 3
 
+3. Browse to the  **Users** node, and then select **Active Users**. 
 
-1. Browse to the  **Users** node, and then select **Active Users**. 
-
-2. Edit the following users to set their location to  **United States**, and assign a Microsoft Enterprise Mobility + Security E5 license:
-
+4. Edit the following users to set their location to  **United States**, and assign a **Microsoft Enterprise Mobility + Security E5** license:
 
 - Adam Hobbs
 
@@ -103,76 +98,72 @@ The main tasks for this exercise are as follows:
 
 #### Task 2: Assign a Global Administrator
   
-- In the Office 365 Admin center, from the Active Users list, edit and then assign Adam Hobbs a Global Administrator. Close Microsoft Edge when you are finished.
+1. In the Office 365 Admin center, from the Active Users list, edit and then assign **Adam Hobbs** as a **Global Administrator**. 
+
+2. Close Microsoft Edge when you are finished.
 
 
 
 #### Task 3: Verify user access
   
-1. On  **LON-CL4**, open Microsoft Edge and navigate to https://portal.office.com.
+1. On  **LON-CL4**, open Microsoft Edge and navigate to [**https://portal.office.com**](https://portal.office.com).
 
 2. Sign in with the following account:
 
-
-- Username:  **Abbi@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Abbi@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
-
-1. Notice that Abbi Skinner does not have access to the Admin console.
-
+3. Notice that Abbi Skinner does not have access to the Admin console.
 
   **Open the Intune Company Portal**
 
-1. Use Microsoft Edge to navigate to https://portal.manage.microsoft.com.
+4. Use Microsoft Edge to navigate to [**https://portal.manage.microsoft.com**](https://portal.manage.microsoft.com).
 
-2. Sign in with the following account:
+5. Sign in with the following account:
 
-
-- Username:  **Abbi@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Abbi@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
->  **Note:** Abbi Skinner should have access to the Company Portal website. No devices are yet configured.
+    >  **Note:** Abbi Skinner should have access to the Company Portal website. No devices are yet configured.
 
-1. Close Microsoft Edge.
+6. Close Microsoft Edge.
 
 
 
 #### Task 4: Verify administrator access
   
-1. On  **LON-CL4**, use Microsoft Edge to navigate to https://portal.office.com/AdminPortal.
+1. On  **LON-CL4**, use Microsoft Edge to navigate to [**https://portal.office.com/AdminPortal**](https://portal.office.com/AdminPortal).
 
 2. Sign in with the following account:
 
-
-- Username:  **Adam@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Adam@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
-
 3. Under Admin centers, attempt to open the  **Intune** admin center.
 
->  **Note:** The **Intune console** in the Azure portal attempts to open. Adam Hobbs should have access.
+    >  **Note:** The **Intune console** in the Azure portal attempts to open. Adam Hobbs should have access.
 
   **Open the Intune classic portal**
 
-4. Open Internet Explorer and navigate to https://admin.manage.microsoft.com.
+4. Open Internet Explorer and navigate to [**https://admin.manage.microsoft.com**](https://admin.manage.microsoft.com).
 
 5. Sign in with the following account:
 
-
-  - Username:  **Adam@initialsMMDDYY.onmicrosoft.com**
+  - Username:  **Adam@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
   - Password:  **Pa55w.rd**
 
->  **Note:** If prompted, install Silverlight with default settings.
+    >  **Note:** If prompted, install Silverlight with default settings.  
 >  **Note:** Adam Hobbs should have access to the Intune classic portal website.
 
 6. Close Internet Explorer and Microsoft Edge.
 
 
 >  **Result**: After completing this exercise, you should have assigned Intune licenses to users, assigned Global Administrator access to a user, verified that users can access the Company Portal, and verified that the Global Administrator can manage Intune from both the Azure portal and the Intune classic portal.
+
 
 
 ## Exercise 2: Delegating permissions and using the Azure portal
@@ -193,15 +184,13 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Create an Azure AD group to manage role membership
   
-1. On  **LON-CL3**, open Microsoft Edge to navigate to https://portal.azure.com.
+1. On  **LON-CL3**, open Microsoft Edge to navigate to [**https://portal.azure.com**](https://portal.azure.com).
 
 2. Sign in with the following account:
 
-
-- Username:  **GAdmin @initialsMMDDYY.onmicrosoft.com**
+- Username:  **GAdmin@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password: The password you created in Module 3
-
 
 3. In the Navigation pane, select  **Azure Active Directory.**
 
@@ -215,7 +204,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 2: Create a custom Intune role
   
-1. In the Azure portal, click  **More services**, in the search box, enter  **Intune**, and then in the results, under  **Services**, select  **Intune**.
+1. In the Azure portal, click  **All services**, in the search box, enter  **Intune**, and then in the results, under  **Services**, select  **Intune**.
 
 2. In the  **Intune console**, select  **Intune roles**.
 
@@ -227,13 +216,13 @@ The main tasks for this exercise are as follows:
 
 6. Next to  **Assign**, select  **Yes**.
 
-7. Next to  **Read**, select  **Yes**, ** **and then select  **OK** twice.
+7. Next to  **Read**, select  **Yes**, and then select  **OK** twice.
 
 8. Select  **Create**.
 
 9. Select the role  **Adatum Intune Test**.
 
-10. Select  **Assignments**, ** **and then select  **Assign**.
+10. Select  **Assignments**, and then select  **Assign**.
 
 11. In the  **Assignmentname** box, enter **Test assignment**.
 
@@ -251,28 +240,27 @@ The main tasks for this exercise are as follows:
 
 #### Task 3: Verify custom role permissions
   
-1. On  **LON-CL4**, use Microsoft Edge to navigate to https://portal.azure.com.
+1. On  **LON-CL4**, use Microsoft Edge to navigate to [**https://portal.azure.com**](https://portal.azure.com).
 
 2. Sign in with the following account:
 
-
-- Username:  **Allan @initialsMMDDYY.onmicrosoft.com**
+- Username:  **Allan@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
-
 3. In the Azure portal, click More services, and then in the search box, enter  **Intune** and then in the results, select **Intune**.
 
-4. In the  **Intune console**, select  **Device enrollment**.
+4. In the  **Intune console**, select  **Device enrollment**.  
 You should not be able to view any data.
 
-5. Click back to Microsoft Intune, and then in the  **Intune console**, select  **Device compliance**. 
+5. Click back to Microsoft Intune, and then in the  **Intune console**, select  **Device compliance**.  
 You should be able to view the  **Device compliance** blade.
 
 6. Close Microsoft Edge.
 
 
 >  **Result**: After completing this exercise, you should have created an Azure AD group to manage membership in the custom role, created a custom Intune role and assigned permissions to the role, and verified that the user has the delegated permissions assigned by the role.
+
 
 
 ## Exercise 3: Enrolling Windows 10 devices in Intune
@@ -295,15 +283,13 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Configure Azure AD for automatic device enrollment
   
-1. On  **LON-CL3**, open Microsoft Edge and navigate to https://portal.azure.com.
+1. On  **LON-CL3**, open Microsoft Edge and navigate to [**https://portal.azure.com**](https://portal.azure.com).
 
 2. Sign in with the following account:
 
-
-- Username:  **GAdmin@initialsMMDDYY.onmicrosoft.com**
+- Username:  **GAdmin@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password: The password you created in Module 3
-
 
 3. Select  **Azure Active Directory**, and then select  **Mobility (MDM and MAM)**.
 
@@ -311,7 +297,7 @@ The main tasks for this exercise are as follows:
 
 5. Next to  **MDM user scope**, select  **All**, and then select  **Save**.
 
-6. In the Microsoft Azure navigation pane, click  **More services**, scroll down and then click  **Intune**.
+6. In the Microsoft Azure navigation pane, click  **All services**, scroll down and then click  **Intune**.
 
 7. In the Microsoft Intune pane, click the notification that states  **You’re using Office 365 for device management. Click here to add Intune**.
 
@@ -321,7 +307,7 @@ The main tasks for this exercise are as follows:
 
 10. On the  **Devices** page, select **Azure AD devices**.
 
-11. Next to  **LON-CL3**, at the end of the row, click the three dots (…) and then click  **Delete**. Click  **Yes** when prompted.
+11. Next to  **LON-CL3**, at the end of the row, click the three dots (**…**) and then click  **Delete**. Click  **Yes** when prompted.
 
 12. Repeat step 11 for  **LON-CL4**.
 
@@ -333,15 +319,13 @@ The main tasks for this exercise are as follows:
 
 2. Select  **Accounts**.
 
-3. Select  **Access work or school**, ** **and then select  **Connect.**
+3. Select  **Access work or school**, and then select  **Connect.**
 
 4.  Sign in with the following account:
 
-
-- Username:  **Abbi@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Abbi@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
-
 
 5. Wait for the connection and enrollment process to complete and then click  **Done**.
 
@@ -365,13 +349,11 @@ The main tasks for this exercise are as follows:
   
 1. On LON-CL3, in Azure portal, create the following group:
 
-
 - Name:  **Windows devices dynamic**
 
 - Type:  **Dynamic Device**
 
 - Dynamic membership rule:  **deviceOSType contains Windows**
-
 
 2. View the group membership.
 
@@ -379,6 +361,7 @@ The main tasks for this exercise are as follows:
 
 
 >  **Result**: After completing this exercise, you should have configured Azure AD for automatic device enrollment, successfully joined a Windows 10 device to Azure AD and enrolled it in Intune, verified that you can view the device in the Intune console, and successfully created a dynamic device group in Azure AD for Windows devices.
+
 
 
 ## Exercise 4: Using the Intune portal
@@ -401,17 +384,15 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Verify that the Intune classic portal does not open in Microsoft Edge
   
-1. On  **LON-CL3**, open the Microsoft Edge browser, attempt to navigate to https://admin.manage.microsoft.com.
+1. On  **LON-CL3**, open the Microsoft Edge browser, attempt to navigate to [**https://admin.manage.microsoft.com**](https://admin.manage.microsoft.com).
 
 2. Sign in with the following account:
 
-
-- Username:  **GAdmin@initialsMMDDYY.onmicrosoft.com**
+- Username:  **GAdmin@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password: The password you created in Module 3
 
-
-3. Verify that you see the message “Unsupported browser or browser mode.“
+3. Verify that you see the message **"Unsupported browser or browser mode."**
 
 4. Close Microsoft Edge.
 
@@ -419,15 +400,13 @@ The main tasks for this exercise are as follows:
 
 #### Task 2: Verify that accessing the Intune classic portal from Internet Explorer requires Silverlight
   
-1. On  **LON-CL3**, open Internet Explorer, attempt to navigate to https://admin.manage.microsoft.com.
+1. On  **LON-CL3**, open Internet Explorer, attempt to navigate to [**https://admin.manage.microsoft.com**](https://admin.manage.microsoft.com).
 
 2. Sign in with the following account:
 
-
-- Username:  **Adam@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Adam@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
-
 
 3. Verify that you are prompted to download Silverlight.
 
@@ -443,7 +422,7 @@ The main tasks for this exercise are as follows:
 
 2. Verify you can view  **LON-CL3** in the list of devices.
 
-3. Select  **Groups**, ** **and then verify that you see the message “Intune groups are now managed as groups in Azure Active Directory!”
+3. Select  **Groups**, and then verify that you see the message **"Intune groups are now managed as groups in Azure Active Directory!"**
 
 4. Close Internet Explorer.
 
@@ -468,6 +447,7 @@ How are device profiles managed in the Intune classic portal?
 
 
 
+
 # Lab B: Managing devices with Intune
   
 ### Scenario
@@ -485,17 +465,17 @@ How are device profiles managed in the Intune classic portal?
 
 - Configure software updates.
 
->  **Note:** The lab steps for this course change frequently due to updates to Microsoft Azure. Microsoft Learning updates the lab steps frequently, so they are not available in this manual. Your instructor will provide you with the lab documentation.
+    >  **Note:** The lab steps for this course change frequently due to updates to Microsoft Azure. Microsoft Learning updates the lab steps frequently, so they are not available in this manual. Your instructor will provide you with the lab documentation.
 
 ### Lab setup
   
  Estimated Time: 25 minutes
 
-Virtual machines:  **20697-2C-LON-DC1**, ** 20697-2C-LON-CL3**, and  **20697-2C-LON-CL4**
+Virtual machines:  **20697-2C-LON-DC1**, **20697-2C-LON-CL3**, and  **20697-2C-LON-CL4**
 
- User name:  **Adatum\Administrator**
+ - User name:  **Adatum\\Administrator**
 
- Password:  **Pa55w.rd**
+ - Password:  **Pa55w.rd**
 
  For this lab, you will use the available virtual machine environment. Before you begin the lab, complete the following steps:
 
@@ -507,20 +487,22 @@ Virtual machines:  **20697-2C-LON-DC1**, ** 20697-2C-LON-CL3**, and  **20697-2C-
 
 4. Sign in by using the following credentials: 
 
-
-  - User name:  **Adatum\Administrator**
+  - User name:  **Adatum\\Administrator**
 
   - Password:  **Pa55w.rd**
 
-
 5. Repeat steps 2 and 3 for virtual machines  **20697-2C-LON-CL3** and **20697-2C-LON-CL4**.
 
-6. On  **LON-CL3** and ** LON-CL4**, sign in as  **Admin** with the password **Pa55w.rd**.
+6. On  **LON-CL3** and **LON-CL4**, sign in as  **Admin** with the password **Pa55w.rd**.
 
 7. For Internet access, start  **MT17B-WS2016-NAT**. You do not need to sign in to this VM.
 
 
- To successfully complete this lab, you need to first complete all the labs in Module 2, “Traditional Windows 10 deployment in an enterprise,” all the labs in Module 3, “Managing Windows 10 sign-in and identity,“ and Lab A in this lesson.
+   To successfully complete this lab, you need to first complete all the labs in  
+**Module 2, "Traditional Windows 10 deployment in an enterprise,"** all the labs in   
+**Module 3, "Managing Windows 10 sign-in and identity,"** and  
+**Lab A** in this lesson.
+
 
 
 ## Exercise 1: Working with Intune device profiles
@@ -541,17 +523,15 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Create a VPN device profile
   
-1. On  **LON-CL3**, open Microsoft Edge, and navigate to http://portal.azure.com. 
+1. On  **LON-CL3**, open Microsoft Edge, and navigate to [**https://portal.azure.com**](https://portal.azure.com). 
 
 2. Sign in with the following account: 
 
-
-  - Username:  **Adam@initialsMMDDYY.onmicrosoft.com**
+  - Username:  **Adam@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
   - Password:  **Pa55w.rd**
 
-
-3. Click  **More services**.
+3. Click  **All services**.
 
 4. In the  **Search** box enter **Intune**, and then in the results, select  **Intune**.
 
@@ -571,31 +551,29 @@ The main tasks for this exercise are as follows:
 
 12. Under  **Servers**, enter the following information, and then select  **Add**:
 
-
 - Description:  **Adatum VPN Server**
 
 - IP Address or FQDN:  **vpn.adatum.com**
 
 - Default server:  **True**
 
+13. Next to  **Connection type**, select **F5 Edge Client**. 
 
-13. Next to  **Connection type**, ** **select ** F5 Edge Client**. 
-
-14. For the authentication model, select ** Username and password**. 
+14. For the authentication model, select **Username and password**. 
 
 15. In the  **Custom XML** box, enter the following code:
 
   ```
-  &lt;f5-vpn-conf&gt;&lt;single-sign-on-credential /&gt;&lt;/f5-vpn-conf&gt;
+  <f5-vpn-conf><single-sign-on-credential /></f5-vpn-conf>
   ```
 
-16. Select ** OK** twice, and then select **Create**. 
+16. Select **OK** twice, and then select **Create**. 
 
 
 
 #### Task 2: Deploy the VPN device profile
   
-- On  **LON-CL3**, on the  **Adatum VPNdevice configuration profile** blade, assign the profile to the **Windows Devices Dynamic** Azure AD group.
+1. On  **LON-CL3**, on the  **Adatum VPNdevice configuration profile** blade, assign the profile to the **Windows Devices Dynamic** Azure AD group.
 
 
 
@@ -603,7 +581,7 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-CL3**, in the Azure portal, select  **Microsoft Intune**.
 
-2. Select  **Devices**, ** **and then select  **All devices**.
+2. Select  **Devices**, and then select  **All devices**.
 
 3. Select  **LON-CL3**, and then select  **Sync**.
 
@@ -611,10 +589,11 @@ The main tasks for this exercise are as follows:
 
 5. Right-click  **Start**, and then select  **Network connections**.
 
-6. Select  **VPN**, ** **and then verify that  **Adatum VPN** appears in **VPN** list.
+6. Select  **VPN**, and then verify that  **Adatum VPN** appears in **VPN** list.
 
 
 >  **Result**: After completing this exercise, you should have created a VPN device profile, deployed the device profile to a group of devices, and verified that the profile was successfully deployed.
+
 
 
 ## Exercise 2: Configuring conditional access
@@ -639,13 +618,11 @@ The main tasks for this exercise are as follows:
 
 2. Create a policy with the following settings:
 
-
 - Name:  **Password compliance**
 
 - Platform:  **Windows 10 and later**
 
 - Require a password to unlock mobile devices:  **True**
-
 
 3. Assign the policy to the  **Sales** group.
 
@@ -667,31 +644,29 @@ The main tasks for this exercise are as follows:
 
 7. Select  **Select**, and then in the  **Search Applications** box, enter **Exchange**.
 
-8. Select  **Office 365 Exchange Online**, ** **and then select  **Select**.
+8. Select  **Office 365 Exchange Online**, and then select  **Select**.
 
-9. Select  **Done**, and then under  **Access controls**, ** **select  **Grant**.
+9. Select  **Done**, and then under  **Access controls**, select  **Grant**.
 
 10. Select  **Block access**, and then select  **Select.**
 
-11. Under  **Enable policy**, select  **On**, ** **and then select  **Create**.
+11. Under  **Enable policy**, select  **On**, and then select  **Create**.
 
 
 
 #### Task 3: Verify that the conditional access policy is working
   
-1. On  **LON-CL3**, open a new Microsoft Edge tab, then and open http://office.com.
+1. On  **LON-CL3**, open a new Microsoft Edge tab, then and open [**https://office.com**](https://office.com).
 
 2. Attempt to sign in with the following account:
 
-
-- Username:  **Ada@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Ada@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
-
 3. Verify that you receive the message “You don’t have access to this.”
 
-4. Select  **More details**. You should see the message “Triggered by conditional access”.
+4. Select  **More details**. You should see the message **"Triggered by conditional access"**.
 
 5. Switch back to the  **Microsoft Azure** page and select the **Exchange Online conditional access** policy.
 
@@ -699,7 +674,7 @@ The main tasks for this exercise are as follows:
 
 7. Click  **Save**.
 
-8. Switch back to the Office **.**com web site. Refresh until you can sign in successfully.
+8. Switch back to the **Office.com** web site. **Refresh** until you can sign in successfully.
 
 9. Close Microsoft Edge.
 
@@ -723,22 +698,19 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Create and assign a Windows 10 update ring
   
-1. On  **LON-CL3**, open Microsoft Edge, and navigate to http://portal.azure.com. 
+1. On  **LON-CL3**, open Microsoft Edge, and navigate to [**https://portal.azure.com**](https://portal.azure.com). 
 
 2. Sign in with the following account: 
 
-
-- Username:  **Adam@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Adam@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
-
-3. Click  **More services**.
+3. Click  **All services**.
 
 4. In the  **Search** box enter **Intune**, and then in the results, select  **Intune**.
 
 5. From the Software updates node, create a Windows 10 update ring with the following settings:
-
 
 - Name:  **Windows 10 update ring**
 
@@ -755,7 +727,6 @@ The main tasks for this exercise are as follows:
 - Feature update deferral period (days):  **30**
 
 - Delivery optimization download mode:  **HTTP blended with peering behind the same NAT**
-
 
 6. Assign the ring to the  **Windows Devices Dynamic** group.
 
@@ -779,6 +750,8 @@ The main tasks for this exercise are as follows:
 **Question** 
 In the lab, you chose to install updates from the Windows 10 update ring automatically outside of the device’s active hours. When might you decide that an update should be installed and the device restarted without user consent?
 
+
+##
 
 
 ©2016 Microsoft Corporation. All rights reserved.

--- a/Instructions/206972C_LAB_08.md
+++ b/Instructions/206972C_LAB_08.md
@@ -1,4 +1,4 @@
-# Module 8: Configuring and using Microsoft Store for Business
+﻿# Module 8: Configuring and using Microsoft Store for Business
 # Lab: Deploying apps and Windows 10 by using Microsoft Store for Business
   
 ### Scenario
@@ -23,17 +23,17 @@ You located the apps in Microsoft Store, and you want to deploy them to company 
   
  Estimated Time: 70 minutes
 
-Virtual machines:  **LON-DC1**,  **LON-CL1**,  **LON-CL2**, ** LON-CL5**, and ** MT17B-WS2016-NAT**
+Virtual machines:  **LON-DC1**,  **LON-CL1**,  **LON-CL2**, **LON-CL5**, and **MT17B-WS2016-NAT**
 
- Username on  **LON-DC1**,  **LON-CL1** and **LON-CL2**:  **Adatum\Administrator**
+- Username on  **LON-DC1**,  **LON-CL1** and **LON-CL2**:  **Adatum\\Administrator**
 
- Username on  **LON-CL5**: ** Admin**
+- Username on  **LON-CL5**: **Admin**
 
- Password: ** Pa55w.rd**
+- Password: **Pa55w.rd**
 
- Start  **MT17B-WS2016-NAT**, but ** **don’t sign in to it.
+ Start  **MT17B-WS2016-NAT**, but don’t sign in to it.
 
- For this lab, you will use the available VM environment. ** **Before you begin the lab, you must complete the following steps:
+ For this lab, you will use the available VM environment. Before you begin the lab, you must complete the following steps:
 
 1. On the host computer, start  **Hyper-V Manager**.
 
@@ -43,20 +43,17 @@ Virtual machines:  **LON-DC1**,  **LON-CL1**,  **LON-CL2**, ** LON-CL5**, and **
 
 4. Sign in by using the following credentials:
 
-
   - Username:  **Administrator**
 
   - Password:  **Pa55w.rd**
 
   - Domain:  **Adatum**
 
-
 5. Repeat steps 2-4 for  **20697-2C-LON-CL1** and **20697-2C-LON-CL2**.
 
 6. Repeat steps 2 and 3 for  **20697-2C-LON-CL5** and **MT17B-WS2016-NAT**.
 
-7.  ** **Sign in to  **LON-CL5** by using the following credentials:
-
+7.  Sign in to  **LON-CL5** by using the following credentials:
 
   - Username:  **Admin**
 
@@ -84,14 +81,18 @@ After you sign up for Microsoft Store for Business and customize the private sto
 
 #### Task 1: Sign up for Microsoft Store for Business and perform initial configuration
   
-1. On  **LON-CL2**, use Microsoft Edge to browse to Microsoft Store for Business at  **https://www.microsoft.com/business-store**.
+1. On  **LON-CL2**, use Microsoft Edge to browse to Microsoft Store for Business at  [**https://www.microsoft.com/business-store**](https://www.microsoft.com/business-store).
 
-2. Sign in to Microsoft Store for Business as  **GAdmin@YourInitialsMMDDYYoutlook.onmicrosoft.com** with the password that you configured in module 3.
->  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the _YourInitials-MMDDYY_@outlook.com format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF-121817@outlook.com. In this case, you should sign in as  **GAdmin@DF121817outlook.onmicrosoft.com**.
+2. Sign in to Microsoft Store for Business as  **GAdmin@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** with the password that you configured in module 3.
+
+    >  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the **_&lt;YourInitials&gt;&lt;MMDDYY&gt;_@outlook.com** format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF121817@outlook.com. In this case, you should sign in as  **GAdmin@DF121817outlook.onmicrosoft.com**.
+
 3. Accept the  **Microsoft Store for Business and Education Services Agreement**.
 
-4. On the  **Microsoft Store for Business** page, select **Manage**, and then verify that the Sway, OneNote, ** **PowerPoint Mobile, ** **Excel Mobile, ** **and ** **Word Mobile ** **apps show a status of  **Adding** to your private store.
->  **Note:** When you sign up for Microsoft Store for Business, the portal automatically adds Sway, OneNote, PowerPoint Mobile, Excel Mobile, and Word Mobile to your private store. It might take up to 36 hours for the apps to appear in the private store. These apps are automatically available for you to deploy to users.
+4. On the  **Microsoft Store for Business** page, select **Manage**, and then verify that the Sway, OneNote, PowerPoint Mobile, Excel Mobile, and Word Mobile apps show a status of  **Adding** to your private store.
+
+    >  **Note:** When you sign up for Microsoft Store for Business, the portal automatically adds Sway, OneNote, PowerPoint Mobile, Excel Mobile, and Word Mobile to your private store. It might take up to 36 hours for the apps to appear in the private store. These apps are automatically available for you to deploy to users.
+
 5. On  **Settings** page, turn on the **Show offline apps** option.
 
 6. On the menu bar, verify that the private store is named  **Default Directory**.
@@ -100,64 +101,81 @@ After you sign up for Microsoft Store for Business and customize the private sto
 
 8. Locate where you can configure Device Guard signer policies.
 
->  **Note:** When configured, these policies allow apps from Microsoft Store for Business to run on a device that is protected by Windows Defender Device Guard.
+    >  **Note:** When configured, these policies allow apps from Microsoft Store for Business to run on a device that is protected by Windows Defender Device Guard.
 
 
 #### Task 2: Work with roles in Microsoft Store for Business
   
-1. On  **LON-CL2**, use Microsoft Edge to assign Ada Russell the Admin role in Microsoft Store for Business.
+1. On  **LON-CL2**, use Microsoft Edge to assign **Ada Russell** the **Admin** role in Microsoft Store for Business.
 
-2. Assign Holly Spencer the Purchaser ** **role in Microsoft Store for Business.
+2. Assign **Holly Spencer** the **Purchaser** role in Microsoft Store for Business.
 
 3. Verify that the following users have roles in Microsoft Store for Business:
-
 
   - GAdmin:  **Global Admin**
 
   - Ada Russell:  **Admin**
 
-  - Holly Spencer: ** Purchaser**
+  - Holly Spencer: **Purchaser**
 
+4. On  **LON-CL1**, use Internet Explorer to browse to Microsoft Store for Business at  [**https://www.microsoft.com/business-store**](https://www.microsoft.com/business-store).
 
-1. On  **LON-CL1**, use Internet Explorer to browse to Microsoft Store for Business at  **https://www.microsoft.com/business-store**.
+5. Sign in to Microsoft Store for Business as  **Holly@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** with the password **Pa55w.rd**.
 
-2. Sign in to Microsoft Store for Business as  **Holly@YourInitialsMMDDYYoutlook.onmicrosoft.com** with the password ** Pa55w.rd**.
->  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the _YourInitials-MMDDYY_@outlook.com format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF-121817@outlook.com. In this case, you should sign in as  **Holly@DF121817outlook.onmicrosoft.com**.
-3. Verify that Holly has only the  **Quotes**, ** Products &amp; services**,  **My organization**,  **Benefits**,  **Billing, Order history**, ** Partners**, and  **Support** options available in Microsoft Store for Business.
->  **Note:** Holly has the Purchaser role assigned. Purchaser doesn’t have access to **Devices**,  **Permissions**, and  **Settings**.
-4. Locate the Translator ** **app in Microsoft Store for Business, and then get the app. Notice the ellipsis ( **…**) near the  **Install** button.
+    >  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the **_&lt;YourInitials&gt;&lt;MMDDYY&gt;_@outlook.com** format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF121817@outlook.com. In this case, you should sign in as  **Holly@DF121817outlook.onmicrosoft.com**.
 
-5. Verify that when you select the ellipsis ( **…**) button, only the  **Manage** option is available. Notice that **Licensing type** is set to **Online**, but the  **Offline** licensing type also is available.
->  **Note:** Holly has the Purchaser role assigned. Purchaser can’t add apps to the private store.
-6. On  **LON-CL2**, verify that the user GAdmin has the  **Quotes**, ** Products &amp; services**,  **My organization**,  **Benefits**,  **Devices**,  **Billing, Order history**,  **Partners**,  **Permissions**,  **Settings**, ** **and  **Support** options available in Microsoft Store for Business.
->  **Note:** The GAdmin user is a global administrator and has full permissions in Microsoft Store for Business.
-7. Locate the Translator ** **app in Microsoft Store for Business. Verify that you can see the  **License type** options to the left of the **Install** button.
+6. Verify that Holly has only the  **Quotes**, **Products &amp; services**,  **My organization**,  **Benefits**,  **Billing, Order history**, **Partners**, and  **Support** options available in Microsoft Store for Business.
 
-8. Select the ellipsis ( **…**), and then verify that you have the  **Manage** and **Add to private store** options available.
+    >  **Note:** Holly has the Purchaser role assigned. Purchaser doesn’t have access to **Devices**,  **Permissions**, and  **Settings**.
 
-9. Add the Translator ** **app to the private store.
+7. Locate the **Translator** app in Microsoft Store for Business, and then get the app. Notice the ellipsis (**…**) near the  **Install** button.
 
-10. Get the Fresh Paint ** **app, but don’t add it to the private store.
+8. Verify that when you select the ellipsis (**…**) button, only the  **Manage** option is available. Notice that **Licensing type** is set to **Online**, but the  **Offline** licensing type also is available.
 
-11. Locate the Microsoft Remote Desktop ** **app in Microsoft Store for Business, select offline licensing, get the app, and then verify that you can download the Microsoft Remote Desktop package for offline use.
+    >  **Note:** Holly has the Purchaser role assigned. Purchaser can’t add apps to the private store.
+
+9. On  **LON-CL2**, verify that the user GAdmin has the  **Quotes**, **Products &amp; services**,  **My organization**,  **Benefits**,  **Devices**,  **Billing, Order history**,  **Partners**,  **Permissions**,  **Settings**, and  **Support** options available in Microsoft Store for Business.
+
+    >  **Note:** The GAdmin user is a global administrator and has full permissions in Microsoft Store for Business.
+
+10. Locate the **Translator** app in Microsoft Store for Business. Verify that you can see the  **License type** options to the left of the **Install** button.
+
+11. Select the ellipsis (**…**), and then verify that you have the  **Manage** and **Add to private store** options available.
+
+12. Add the Translator app to the private store.
+
+13. Get the **Fresh Paint** app, but don’t add it to the private store.
+
+14. Locate the **Microsoft Remote Desktop** app in Microsoft Store for Business, select **offline licensing**, get the app, and then verify that you can download the Microsoft Remote Desktop package for offline use.
 
 
 
 #### Task 3: Access Microsoft Store for Business
   
-1. On  **LON-CL1**, use the Store ** **app and verify that you can see the following five categories on the toolbar of the Store ** **app:  **Home**,  **Apps**,  **Games**,  **Movies &amp; TV**, and  **Books**.
+1. On  **LON-CL1**, use the Store app and verify that you can see the following five categories on the toolbar of the Store app:  **Home**,  **Apps**,  **Games**,  **Movies &amp; TV**, and  **Books**.
 
-2. Sign in to the Store ** **app by using the  **Abbi@YourInitialsMMDDYYoutlook.onmicrosoft.com** work or school account with the password **Pa55w.rd**, ** **and then add this account to the Windows operating system.
->  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the _YourInitials-MMDDYY_@outlook.com format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF-121817@outlook.com. In this case, you should sign in as  **Abbi@DF121817outlook.onmicrosoft.com**.
-3. In the Store ** **app, verify that you are signed in as  **Abbi Skinner**.
->  **Note:** Although apps added to the private store when you signed up for Microsoft Store for Business, it takes up to 36 hours for apps to appear in the private store. When they are visible, you will get an additional tab in the Store app. This additional tab will be named **Adatum Store**, which you configured earlier in the lab.
-4. Verify that the work or school account that you used in the Store ** **app is connected to your Microsoft account.
->  **Note:** An Azure AD account also is referenced as a work or school account.
-5. Open the  **Local Group Policy Editor**, view the  **Computer Configuration\Administrative Templates\Windows Components\Store\Only display the private store within the Windows Store app** setting, and then read the Help for the setting. Don’t configure this setting.
+2. Sign in to the Store app by using the  **Abbi@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** work or school account with the password **Pa55w.rd**, and then add this account to the Windows operating system.
 
->  **Note:** You don’t configure and test this setting, because the private store has not yet updated with the added apps.
+    >  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the **_&lt;YourInitials&gt;&lt;MMDDYY&gt;_@outlook.com** format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF121817@outlook.com. In this case, you should sign in as  **Abbi@DF121817outlook.onmicrosoft.com**.
+
+3. In the Store app, verify that you are signed in as  **Abbi Skinner**.
+
+    >  **Note:** Although apps added to the private store when you signed up for Microsoft Store for Business, it takes up to 36 hours for apps to appear in the private store. When they are visible, you will get an additional tab in the Store app. This additional tab will be named **Adatum Store**, which you configured earlier in the lab.
+
+4. Verify that the work or school account that you used in the Store app is connected to your Microsoft account.
+
+    >  **Note:** An Azure AD account also is referenced as a work or school account.
+
+5. Open the  **Local Group Policy Editor**, view the:  
+**Computer Configuration\\Administrative Templates\\Windows Components\\Store\\Only display the private store within the Windows Store app** setting, and then read the Help for the setting.  
+Don’t configure this setting.
+
+    >  **Note:** You don’t configure and test this setting, because the private store has not yet updated with the added apps.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have successfully signed up for Microsoft Store for Business and performed initial configuration of the store. You should also have assigned users to Microsoft Store for Business roles and tested how to connect to the store from Windows 10 devices.
+
 
 
 ## Exercise 2: Configuring and using Windows AutoPilot
@@ -180,25 +198,23 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Customize Azure AD company branding
   
-1. On  **LON-DC1**, use Internet Explorer to navigate to Microsoft Azure portal at following URL:  **https://portal.azure.com**.
+1. On  **LON-DC1**, use Internet Explorer to navigate to Microsoft Azure portal at following URL:  [**https://portal.azure.com**](https://portal.azure.com).
 
-2. Sign in to Microsoft Azure portal as  **GAdmin@YourInitialsMMDDYYoutlook.onmicrosoft.com** with the password that you configured in module 3.
+2. Sign in to Microsoft Azure portal as  **GAdmin@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** with the password that you configured in module 3.
 
 3. In the Microsoft Azure portal, configure  **Company Branding** for **Azure Active Directory** by using following settings:
 
+  - Sign-in page background image:  **E:\\Labfiles\\Mod08\\Background.jpg**
 
-  - Sign-in page background image:  **E:\Labfiles\Mod08\Background.jpg**
-
-  - Banner logo:  **E:\Labfiles\Mod08\Adatum280.jpg**
+  - Banner logo:  **E:\\Labfiles\\Mod08\\Adatum280.jpg**
 
   - Sign-in page text:  **20697-2C Adatum.com sign-in page**
 
-  - Square logo image:  **E:\Labfiles\Mod08\Adatum240.jpg**
+  - Square logo image:  **E:\\Labfiles\\Mod08\\Adatum240.jpg**
 
-  - Square logo image, dark theme:  **E:\Labfiles\Mod08\Adatum_dark.jpg**
+  - Square logo image, dark theme:  **E:\\Labfiles\\Mod08\\Adatum_dark.jpg**
 
   - Show option to remain signed in:  **Yes**
-
 
 4. Configure the  **Azure Active Directory** property **Name** to value **20697-2C Azure AD**.
 
@@ -218,32 +234,31 @@ The main tasks for this exercise are as follows:
   Set-ExecutionPolicy RemoteSigned
   ```
 
-3. Obtain  **LON-CL5** device-specific information and save it to the **C:\Computer.csv** file by typing the following script, and then pressing Enter:
+3. Obtain  **LON-CL5** device-specific information and save it to the **C:\\Computer.csv** file by typing the following script, and then pressing Enter:
 
   ```
-  Get-WindowsAutoPilotInfo.ps1 –OutputFile C:\Computer.csv
+  Get-WindowsAutoPilotInfo.ps1 -OutputFile C:\Computer.csv
   ```
 
-4. Review the content of the  **C:\Computer.csv** file.
+4. Review the content of the  **C:\\Computer.csv** file.
 
-5. Map the  **\\LON-DC1\Labfiles** shared folder to drive F, and then use **Administrator** and **Pa55w.rd** as credentials. You can do this by typing the following command, and then pressing Enter:
+5. Map the  **\\\\LON-DC1\\Labfiles** shared folder to drive **F:** using **Administrator** and **Pa55w.rd** as credentials. You can do this by typing the following command, and then pressing Enter:
 
   ```
   NET USE F: \\LON-DC1\Labfiles /user:Administrator Pa55w.rd
   ```
 
-6. Copy the  **C:\Computer.csv** file to drive F.
+6. Copy the  **C:\\Computer.csv** file to drive F.
 
 
 
 #### Task 3: Work with a Windows AutoPilot deployment profile
   
-1. On  **LON-CL2**, use Microsoft Edge ** **to add a new device to Microsoft Store for Business by uploading the  **\\LON-DC1\Labfiles\Computer.csv** file.
+1. On  **LON-CL2**, use Microsoft Edge to add a new device to Microsoft Store for Business by uploading the  **\\\\LON-DC1\\Labfiles\\Computer.csv** file.
 
 2. Verify that the device named  **Virtual Machine** added to Microsoft Store for Business.
 
 3. Create a Windows AutoPilot deployment profile named  **Profile1** that has the following three settings set to **On**:
-
 
   -  **Skip privacy settings**
 
@@ -251,23 +266,24 @@ The main tasks for this exercise are as follows:
 
   -  **Skip End User License Agreement (EULA)**
 
-
 4. Apply  **Profile1** to the device named **Virtual Machine**.
 
-5. Verify that Profile1 ** **applied to the device.
+5. Verify that Profile1 applied to the device.
 
 
 
 #### Task 4: Deploy a device by using Windows AutoPilot
   
-1. On the host computer, apply the  **Generalized** checkpoint to **20697-2C-LON-CL5**, turn on ** **the ** **VM, and then wait while it starts.
+1. On the host computer, apply the  **Generalized** checkpoint to **20697-2C-LON-CL5**, turn on the VM, and then wait while it starts.
 
 2. Configure your region and keyboard layout, and then skip the additional keyboard.
 
 3. Verify that the sign-in page is customized with the Adatum company branding that you added earlier.
 
-4. Sign in as  **Abbi@yourinitialsMMDDYYoutlook.onmicrosoft.com** and use **Pa55w.rd** as the password.
->  **Note:** While Abbi is signing in, notice that you weren’t asked for privacy settings. You disabled that in the Windows AutoPilot deployment profile.
+4. Sign in as  **Abbi@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** and use **Pa55w.rd** as the password.
+
+    >  **Note:** While Abbi is signing in, notice that you weren’t asked for privacy settings. You disabled that in the Windows AutoPilot deployment profile.
+
 5. Skip setting up the PIN for now.
 
 6. When Abbi signs in, use the Settings app to verify that she is a normal user and not an Administrator.
@@ -294,24 +310,26 @@ In this exercise, you want to test the deployment of apps from Microsoft Store f
 
 #### Task 1: Assign a Microsoft Store for Business app
   
-1. On  **LON-CL5**, use Internet Explorer to browse to  **https://portal.office.com**.
->  **Note:** You signed in to Office portal as Abbi Skinner, although you weren’t asked for credentials. You are signed in to **LON-CL5** with an Azure AD account, and the same account is used to access the Office portal.
+1. On  **LON-CL5**, use Internet Explorer to browse to  [**https://portal.office.com**](https://portal.office.com).
+
+    >  **Note:** You signed in to Office portal as Abbi Skinner, although you weren’t asked for credentials. You are signed in to **LON-CL5** with an Azure AD account, and the same account is used to access the Office portal.
+
 2. In Internet Explorer, select  **Mail**, and then set up Outlook.
 
-3. On  **LON-CL1**, in Microsoft Store for Business, assign the Fresh Paint app to the user Abbi Skinner, and then verify that the app is assigned.
+3. On  **LON-CL1**, in Microsoft Store for Business, assign the **Fresh Paint** app to the user **Abbi Skinner**, and then verify that the app is assigned.
 
-4. On  **LON-CL5**, use Internet Explorer to open the message from Microsoft Store, allow blocked content, and then install the app.
+4. On  **LON-CL5**, use Internet Explorer to open the message from Microsoft Store, **allow blocked content**, and then install the app.
 
 5. Verify that you can start the Fresh Paint app, and then close it.
 
 6. On  **LON-CL1**, use Internet Explorer to reclaim the license for Fresh Paint from Abbi Skinner.
 
->  **Note:** You reclaimed the license for the Fresh Paint app from Abbi Skinner. If the app weren’t free, Abbi would not be allowed to run the app.
+    >  **Note:** You reclaimed the license for the Fresh Paint app from Abbi Skinner. If the app weren’t free, Abbi would not be allowed to run the app.
 
 
 #### Task 2: Prepare for the next module
   
- When you finish with the lab, revert the  **LON-CL1**,  **LON-CL2** and **LON-CL5** VMs to their initial state. *Don’t* revert **LON-DC1**:
+ When you finish with the lab, revert the  **LON-CL1**,  **LON-CL2** and **LON-CL5** VMs to their initial state. **_Don’t revert LON-DC1!_**
 
 1. On the host computer, start  **Hyper-V Manager**.
 
@@ -321,7 +339,9 @@ In this exercise, you want to test the deployment of apps from Microsoft Store f
 
 4. Repeat steps 2 and 3 for  **20697-2C-LON-CL2** and **20697-2C-LON-CL5**.
 
->  **Note:** *Don’t* revert **LON-DC1**!  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.
+    >  **Note:** **_Don’t revert LON-DC1!_**  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.
+
+<!-- -->
 
 >  **Result**: After finishing this exercise, you will assign and install an app from Microsoft Store for Business. You will also reclaim the app license.
 
@@ -341,6 +361,8 @@ Why were you unable to view any apps in the private store even though you had ad
 **Question** 
 Can you fully automate a deployment by using Windows AutoPilot?
 
+
+## 
 
 
 ©2016 Microsoft Corporation. All rights reserved.

--- a/Instructions/206972C_LAB_09.md
+++ b/Instructions/206972C_LAB_09.md
@@ -1,4 +1,4 @@
-# Module 9: Deploying apps and managing information access by using Intune
+﻿# Module 9: Deploying apps and managing information access by using Intune
 # Lab: Deploying apps and managing information access by using Intune
   
 ### Scenario
@@ -14,17 +14,18 @@
 
 - Configure a WIP policy in Intune.
 
->  **Note:** The lab steps for this course change frequently due to updates to Microsoft Azure. Microsoft Learning updates the lab steps frequently, so they are not available in this manual. Your instructor will provide you with the lab documentation.
+    >  **Note:** The lab steps for this course change frequently due to updates to Microsoft Azure. Microsoft Learning updates the lab steps frequently, so they are not available in this manual. Your instructor will provide you with the lab documentation.
+
 
 ### Lab setup
   
  Estimated Time: 30 minutes
 
-Virtual machines:  **20697-2C-LON-DC1**, ** 20697-2C-LON-CL3**, and ** 20697-2C-LON-CL4**
+Virtual machines:  **20697-2C-LON-DC1**, **20697-2C-LON-CL3**, and **20697-2C-LON-CL4**
 
- Username:  **Adatum\Administrator**
+- Username:  **Adatum\\Administrator**
 
- Password:  **Pa55w.rd**
+- Password:  **Pa55w.rd**
 
  For this lab, you will use the available virtual machine environment. Before you begin the lab, complete the following steps:
 
@@ -36,15 +37,13 @@ Virtual machines:  **20697-2C-LON-DC1**, ** 20697-2C-LON-CL3**, and ** 20697-2C-
 
 4. Sign in by using the following credentials: 
 
-
-  - Username:  **Adatum\Administrator**
+  - Username:  **Adatum\\Administrator**
 
   - Password:  **Pa55w.rd**
 
-
 5. Repeat steps 2 and 3 for virtual machines  **20697-2C-LON-CL3** and **20697-2C-LON-CL4**.
 
-6. On  **LON-CL3** and ** LON-CL4**, sign in as  **Admin** with the password **Pa55w.rd**.
+6. On  **LON-CL3** and **LON-CL4**, sign in as  **Admin** with the password **Pa55w.rd**.
 
 7. For Internet connectivity, start  **MT17B-WS2016-NAT.** You do not have to sign in to this VM.
 
@@ -74,14 +73,15 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Create an app category
   
-1. On  **LON-CL3**, open Microsoft Edge, and navigate to  **http://portal.azure.com**.
+1. On  **LON-CL3**, open Microsoft Edge, and navigate to  [**https://portal.azure.com**](https://portal.azure.com).
 
 2. Sign in with the following account:
-Username:  **GAdmin** _@initialsMMDDYY_ ** _.onmicrosoft.com_**
 
-Password: The password you created in Module 3
+- Username:  **GAdmin@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**
 
-3. In the navigation pane, select  **More services**.
+- Password: The password you created in Module 3
+
+3. In the navigation pane, select  **All services**.
 
 4. In the  **Search** box, type **Intune**, and then select  **Intune** from the results.
 
@@ -99,7 +99,6 @@ Password: The password you created in Module 3
 
 2. Customize the Company Portal branding with the following information:
 
-
 - Company name:  **Adatum**
 
 - IT department contact name:  **Adatum IT**
@@ -108,13 +107,13 @@ Password: The password you created in Module 3
 
 - IT department email address:  **IT@adatum.com**
 
-- Company privacy statement URL:  **http://adatum.sharepoint.com/IT/Privacy**
+- Company privacy statement URL:  **https://adatum.sharepoint.com/IT/Privacy**
 
-- Support website URL:  **http://adatum.sharepoint.com/IT/Support**
+- Support website URL:  **https://adatum.sharepoint.com/IT/Support**
 
 - Support website name:  **Adatum helpdesk**
 
-- Company logo (light and dark):  **C:\Labfiles\Mod09\Adatumlogo.png**
+- Company logo (light and dark):  **C:\\Labfiles\\Mod09\\Adatumlogo.png**
 
 - Do not show the company name next to the logo.
 
@@ -124,11 +123,11 @@ Password: The password you created in Module 3
   
   **Add Intune as a management tool in the Microsoft Store for Business**
 
-1. On  **LON-CL3**, in Microsoft Edge, open a new tab and navigate to  **http://businessstore.microsoft.com**.
+1. On  **LON-CL3**, in Microsoft Edge, open a new tab and navigate to  [**https://businessstore.microsoft.com**](https://businessstore.microsoft.com).
 
 2. Sign in with the following account:
 
-  - Username:  **GAdmin@** _initialsMMDDYY_ ** _.onmicrosoft.com_**
+  - Username:  **GAdmin@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**
 
   - Password: The password you created in Module 3
 
@@ -136,22 +135,23 @@ Password: The password you created in Module 3
 
 4. Under  **Settings**, select  **Distribute**.
 
-5. Under  **Management tools**, next to  **MicrosoftIntune**, select  **Activate**.
+5. Under  **Management tools**, next to  **Microsoft Intune**, select  **Activate**.
 
 
   **Synchronize Intune with the Microsoft Store for Business**
 
-1. In Microsoft Edge, switch to the  **Dashboard – Microsoft Azure** tab.
+6. In Microsoft Edge, switch to the  **Dashboard – Microsoft Azure** tab.
 
-2. In the  **Mobile apps** workspace, select Microsoft Store for Business.
+7. In the  **Mobile apps** workspace, select **Microsoft Store for Business**.
 
-3. Select  **Enable**, and then verify  **English** is selected.
+8. Select  **Enable**, and then verify  **English** is selected.
 
-4. Select  **Save**, and then select  **Sync**.
+9. Select  **Save**, and then select  **Sync**.
 
-5. In the  **Mobile apps** workspace, select **Apps** to view the list of available apps.
+10. In the  **Mobile apps** workspace, select **Apps** to view the list of available apps.
 
->  **Note:** You should see the apps added in Module 8. It might take some time for the apps to sync.
+    >  **Note:** You should see the apps added in Module 8. It might take some time for the apps to sync.
+
 
 
 #### Task 4: Add apps to Intune and assign to devices
@@ -164,8 +164,7 @@ Password: The password you created in Module 3
 
 3. Select  **Configure App Suite**.
 
-4. Select the following Office 365 apps, and then select ** OK**:
-
+4. Select the following Office 365 apps, and then select **OK**:
 
   -  **Excel**
 
@@ -203,48 +202,48 @@ Password: The password you created in Module 3
 
 15. Select  **Select**.
 
-16. Under  **Type**, select  **Available**, ** **and then select  **Save**.
+16. Under  **Type**, select  **Available**, and then select  **Save**.
 
 
   **Add an LOB app to Intune**
 
-1. Next to  **Microsoft Azure**, select  **Mobile apps – Apps**.
+17. Next to  **Microsoft Azure**, select  **Mobile apps – Apps**.
 
-2. Select  **Add**, and then in the  **App type** list, select **Line-of-business app**.
+18. Select  **Add**, and then in the  **App type** list, select **Line-of-business app**.
 
-3. Select  **App package file**, ** **and then select the  **Browse** icon.
+19. Select  **App package file**, and then select the  **Browse** icon.
 
-4. Navigate to  **C:\Labfiles\Mod09\XMLNotepad.msi**, and then select ** Open**.
+20. Navigate to  **C:\\Labfiles\\Mod09\\XMLNotepad.msi**, and then select **Open**.
 
-5. Select  **OK**, and then select  **App information**.
+21. Select  **OK**, and then select  **App information**.
 
-6. In the  **Description** text box, type **XML text editor for the IT team**.
+22. In the  **Description** text box, type **XML text editor for the IT team**.
 
-7. In the  **Publisher** text ** **box, type  **Microsoft**.
+23. In the  **Publisher** text box, type  **Microsoft**.
 
-8. In the  **Category** list, select **IT tools**.
+24. In the  **Category** list, select **IT tools**.
 
-9. In the  **Information URL** text box, type **http://adatum.sharepoint.com/IT/Tools**.
+25. In the  **Information URL** text box, type **https://adatum.sharepoint.com/IT/Tools**.
 
-10. In the  **Privacy URL** text box, type **http://adatum.sharepoint.com/IT/privacy**.
+26. In the  **Privacy URL** text box, type **https://adatum.sharepoint.com/IT/privacy**.
 
-11. In the  **Developer** text box, type **Microsoft**, and then in the  **Owner** text box, type **Adatum IT**. 
+27. In the  **Developer** text box, type **Microsoft**, and then in the  **Owner** text box, type **Adatum IT**. 
 
-12. Under  **Logo**, ** **select  **Select image**.
+28. Under  **Logo**, select  **Select image**.
 
-13. Select the  **Browse** icon.
+29. Select the  **Browse** icon.
 
-14. Navigate to  **C:\Labfiles\Mod09\notepad.png**, ** **and then select  **Open**.
+30. Navigate to  **C:\\Labfiles\\Mod09\\notepad.png**, and then select  **Open**.
 
-15. Select  **OK** twice, and then select **Add**.
+31. Select  **OK** twice, and then select **Add**.
 
-16. In the  **XML Notepad 2007** blade, select **Assignments**.
+32. In the  **XML Notepad 2007** blade, select **Assignments**.
 
-17. Select  **Select groups**, and then select  **Windows devices**.
+33. Select  **Select groups**, and then select  **Windows devices**.
 
-18. Select  **Select**.
+34. Select  **Select**.
 
-19. Under  **Type**, select  **Required**, and then select  **Save**.
+35. Under  **Type**, select  **Required**, and then select  **Save**.
 
 
 
@@ -252,7 +251,9 @@ Password: The password you created in Module 3
   
 - On  **LON-CL3**, in  **Access work or school settings**, sync device settings for  **Abbi Skinner**.
 
->  **Note:** Wait for the settings to sync and for XML Notepad 2007 to install. XML A link to XML Notepad 2007 will appear on the Desktop.
+    >  **Note:** Wait for the settings to sync and for XML Notepad 2007 to install. XML A link to XML Notepad 2007 will appear on the Desktop.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have successfully:Created an app category in Intune.Customized the Company Portal.Synchronized Intune with the Microsoft Store for Business, added Microsoft Store for Business apps to Intune.Added Office 365 ProPlus and LOB apps to Intune, and assigned them to a device group.Installed an app from the Company portal.
 
@@ -285,7 +286,7 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-CL3**, in Microsoft Edge, switch to the  **Dashboard – Microsoft Azure** tab.
 
-2. In the navigation pane, select  **More services**.
+2. In the navigation pane, select  **All services**.
 
 3. In the  **Search** box, type **Intune**, and then select  **Intune** from the results.
 
@@ -295,9 +296,9 @@ The main tasks for this exercise are as follows:
 
 6. Add a policy with the following settings
 
-  - Name:  **Windows 10 WIP test policy**
+ - Name:  **Windows 10 WIP test policy**
 
-  - Platform:  **Windows 10**
+ - Platform:  **Windows 10**
 
  - Enrollment state:  **With enrollment**
 
@@ -306,13 +307,13 @@ The main tasks for this exercise are as follows:
   
 1. Select the following apps to protect:
 
-  - Microsoft Edge
+  - **Microsoft Edge**
 
-  - Notepad
+  - **Notepad**
 
-2. Set the WIP-protection mode to  **Allowoverrides**.
+2. Set the WIP-protection mode to  **Allow overrides**.
 
-3. Set the corporate identity to  **adatum.com**.
+3. Set the corporate identity to  **Adatum.com**.
 
 
 
@@ -346,15 +347,15 @@ The main tasks for this exercise are as follows:
   Cipher /rc:\users\admin\documents\ADATUMDRA
   ```
 
-3. When prompted, type  **Pa55w.rd**, ** **and then confirm the password.
+3. When prompted, type  **Pa55w.rd**, and then confirm the password.
 
 4. Switch to Microsoft Edge, and under  **Data protection**, select the  **Browse** icon.
 
 5. Browse to the  **Documents** folder, select the **ADATUMDRA.cer** file, and then select **Open**.
 
-6. Under  **Show the enterprise data protection icon**, select  **On**. ** **
+6. Under  **Show the enterprise data protection icon**, select  **On**. 
 
-7. Select  **OK**, ** **and then select  **Create**.
+7. Select  **OK**, and then select  **Create**.
 
 
 
@@ -363,20 +364,21 @@ The main tasks for this exercise are as follows:
 1. Assign the policy to the  **Windows devices** group.
 
 2. On  **LON-CL3**, in  **Access work or school settings**, sync device settings for  **Abbi Skinner**.
->  **Note:** Wait for the settings to sync.
-3. In Edge, navigate to  _initialsMMDDYY_ ** _.sharepoint.com_**.
+
+    >  **Note:** Wait for the settings to sync.
+
+3. In Edge, navigate to  **https://*&lt;initials&gt;&lt;MMDDYY&gt;*.sharepoint.com**.
 
 4. If prompted, sign in with the credentials:
 
-
-  - Usename:  **Abbi@** _initialsMMDDYY_ ** _.onmicrosoft.com_**
+  - Usename:  **Abbi@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**
 
   - Password:  **Pa55w.rd**
 
+5. Start Internet Explorer and navigate to  **https://*&lt;initials&gt;&lt;MMDDYY&gt;*.sharepoint.com**.
 
-5. Start Internet Explorer and navigate to  _initialsMMDDYY_ ** _.sharepoint.com_**.
+    >  **Note:** You should not be able to successfully navigate to the SharePoint site in internet explorer because it is not an allowed app.
 
->  **Note:** You should not be able to successfully navigate to the SharePoint site in internet explorer because it is not an allowed app.
 
 
 #### Task 6: Create a wipe request
@@ -410,6 +412,8 @@ In the lab, you created a custom Office suite and assigned it to users. In your 
 **Question** 
 In the lab, you set the corporate identity to  **adatum.com**. In this field, you can list multiple domains. In which situations would you use multiple domains?
 
+
+##  
 
 
 ©2016 Microsoft Corporation. All rights reserved.

--- a/Instructions/206972C_LAB_10.md
+++ b/Instructions/206972C_LAB_10.md
@@ -1,4 +1,4 @@
-# Module 10: Managing data access for Windows-based devices
+﻿# Module 10: Managing data access for Windows-based devices
 # Lab A: Implementing and using Work Folders
   
 ### Scenario
@@ -22,10 +22,9 @@ Virtual machines:
 
 -  **20697-2C-LON-CL4**
 
+-  **MT17B-WS2016-NAT**
 
-  **MT17B-WS2016-NAT**
-
- User name:  **Adatum\Administrator**,  **Adatum\Adam**, and  **Admin**.
+ User name:  **Adatum\\Administrator**,  **Adatum\\Adam**, and  **Admin**.
 
  Password:  **Pa55w.rd**
 
@@ -37,11 +36,13 @@ Virtual machines:
 
 3. In the  **Actions** pane, click **Connect**. Wait until the virtual machine starts. 
 
-4. Sign in using the following credentials: 
-User name:  **Adatum**\ **Administrator**
-Password:  **Pa55w.rd**
+4. Sign in using the following credentials:
+ 
+- User name:  **Adatum\\Administrator**
 
-5. Repeat steps 2 and 3 for  **20697-2C-LON-CL2**. Sign in as  **Adatum\Adam** with the password of **Pa55w.rd**.
+- Password:  **Pa55w.rd**
+
+5. Repeat steps 2 and 3 for  **20697-2C-LON-CL2**. Sign in as  **Adatum\\Adam** with the password of **Pa55w.rd**.
 
 6. Start  **20697-2C-LON-CL4**, and sign in as  **Admin** with password **Pa55w.rd**. 
 
@@ -75,14 +76,13 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-DC1**, use Windows PowerShell to install the  **FS-SyncShareService** feature by using the **Install-WindowsFeature** cmdlet.
 
-2. Use Server Manager ** **to create a ** **new sync share. Use the following data:
+2. Use **Server Manager** to create a new **Sync share**. Use the following data:
 
+  - Local path:  **C:\\syncshare1**
 
-  - Local path:  **C:\syncshare1**
+  - Structure for user folders: **User alias**
 
-  - Structure for user folders: ** User alias**
-
-  - Grant sync access to groups: ** Managers**
+  - Grant sync access to groups: **Managers**
 
   - Device policies: No policy is selected
 
@@ -97,13 +97,14 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-DC1**, use the  **Group Policy Management Console** to create and link a Group Policy named **Deploy Work Folders** to the **Managers** OU.
 
-2. For the Deploy Work Folders Group Policy, in the Group Policy Management Editor, browse to  **User Configuration\Policies\Administrative Templates\Windows Components\Work Folders**.
+2. For the Deploy Work Folders Group Policy, in the Group Policy Management Editor, browse to:  
+**User Configuration\\Policies\\Administrative Templates\\Windows Components\\Work Folders**.
 
 3. Enable the  **Specify Work Folders settings** setting, configure it with **https://lon-dc1.adatum.com** as **Work Folders URL**, and then select the  **Force automatic setup** check box.
 
-4. On  **LON-CL2**, sign out, and then sign back in as  **adatum\adam** with the password **Pa55w.rd**.
+4. On  **LON-CL2**, sign out, and then sign back in as  **adatum\\adam** with the password **Pa55w.rd**.
 
-5. Use  **File Explorer** to create a new ** **text document in  **Work Folders** named **On LON-CL2**.
+5. Use  **File Explorer** to create a new text document in  **Work Folders** named **On LON-CL2**.
 
 
 
@@ -111,11 +112,11 @@ The main tasks for this exercise are as follows:
   
 1. Sign in to  **LON-CL4** as **Admin**.
 
-2. Map the  **J:** drive to **\\LON-DC1\CertEnroll** as **Adatum\Administrator**.
+2. Map the  **J:** drive to **\\\\LON-DC1\\CertEnroll** as **Adatum\\Administrator**.
 
-3. Create a new management console with the ** Certificates** snap-in for the local computer.
+3. Create a new management console with the **Certificates** snap-in for the local computer.
 
-4. Import the  **LON-DC1.Adatum.com_AdatumCA.crt** file from the ** J:** drive to the **Trusted Root Certification Authorities** store.
+4. Import the  **LON-DC1.Adatum.com_AdatumCA.crt** file from the **J:** drive to the **Trusted Root Certification Authorities** store.
 
 5. Close all open windows without saving.
 
@@ -123,38 +124,37 @@ The main tasks for this exercise are as follows:
 
 #### Task 4: Deploy Work Folders
   
-1. On  **LON-CL4**, use the  **Work FoldersControlPanel** item ** **to set up Work Folders. Use the following settings:
-
+1. On  **LON-CL4**, use the  **Work FoldersControlPanel** item to set up Work Folders. Use the following settings:
 
   - Work Folders URL:  **https://lon-dc1.adatum.com**
 
-  - Credentials:  **adatum\adam** with the password **Pa55w.rd**
+  - Credentials:  **adatum\\adam** with the password **Pa55w.rd**
 
-
-1. Verify that the file  **On LON-CL2.txt** is available in Work Folders on the LON-CL4 computer.
+2. Verify that the file  **On LON-CL2.txt** is available in Work Folders on the LON-CL4 computer.
 
 
 
 #### Task 5: Perform Work Folders synchronization
   
-1. On  **LON-CL4**, in  **Work Folders**, create a new ** **text document named  **On LON-CL4.txt**. 
+1. On  **LON-CL4**, in  **Work Folders**, create a new text document named  **On LON-CL4.txt**. 
 
-2. Switch to  **LON-CL2**, and in ** Work Folders**, verify that the  **On LON-CL4** file is displayed.
+2. Switch to  **LON-CL2**, and in **Work Folders**, verify that the  **On LON-CL4** file is displayed.
 
->  **Note:** In Windows 10, Work Folders synchronizes immediately. In Windows 8.1, it could take up to 10 minutes for synchronization.
-3. Disable the Ethernet ** **network connection by using the  **Administrator** credentials ** **and the password  **Pa55w.rd**.
+    >  **Note:** In Windows 10, Work Folders synchronizes immediately. In Windows 8.1, it could take up to 10 minutes for synchronization.
 
-4. In  **Work Folders**, modify the file  **On LON-CL2** by adding the content: ** Modified offline**.
+3. Disable the Ethernet network connection by using the  **Administrator** credentials and the password  **Pa55w.rd**.
 
-5. In  **Work Folders**, create a new ** **text document named  **Offline LON-CL2**.
+4. In  **Work Folders**, modify the file  **On LON-CL2** by adding the content: **Modified offline**.
 
-6. On  **LON-CL4**, in  **Work Folders**, modify the file  **On LON-CL2.txt** by adding the content ** Online modification**.
+5. In  **Work Folders**, create a new text document named  **Offline LON-CL2**.
 
-7. On  **LON-CL2**, enable the Ethernet ** **network connection. Use username  **Administrator** and the password **Pa55w.rd** as the credentials.
+6. On  **LON-CL4**, in  **Work Folders**, modify the file  **On LON-CL2.txt** by adding the content **Online modification**.
 
-8. On  **LON-CL2**, verify that files now display in Work Folders, including On LON-CL2 ** **and On LON-CL2-LON-CL2.
+7. On  **LON-CL2**, enable the Ethernet network connection. Use username  **Administrator** and the password **Pa55w.rd** as the credentials.
 
->  **Note:** Because the file was modified at two locations, a conflict occurred, and one of the copies was renamed.
+8. On  **LON-CL2**, verify that files now display in Work Folders, including **On LON-CL2** and **On LON-CL2-LON-CL2**.
+
+    >  **Note:** Because the file was modified at two locations, a conflict occurred, and one of the copies was renamed by appending the name of the computer where the confilct occured.
 
 
 #### Task 6: Prepare for the next lab
@@ -197,10 +197,9 @@ Virtual machines:
 
 -  **20697-2C-LON-CL2**
 
+-  **MT17B-WS2016-NAT**
 
-  **MT17B-WS2016-NAT**
-
- User name: Adatum\Administrator for  **LON-DC1**, and use Adatum\Adam for  **LON-CL2**.
+User name: **Adatum\\Administrator** for  **LON-DC1**, and use **Adatum\\Adam** for  **LON-CL2**.
 
  For this lab, you will use the available virtual machine environment. All virtual machines should be running from the previous lab.
 
@@ -233,7 +232,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Configure the OneDrive sync client
   
-1. On  **LON-CL2**, run  **odopen://sync?useremail=Adam@yourdomain.onmicrosoft.com** and sign in as ** **adam by using the password of  **Pa55w.rd**. (Where yourdomain is the tenant domain that you configured in previous labs.)
+1. On  **LON-CL2**, run  **odopen://sync?useremail=Adam@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** and sign in as adam by using the password of  **Pa55w.rd**. (Using the tenant domain that you configured in previous labs.)
 
 2. Accept the default settings as you configure the OneDrive client.
 
@@ -247,7 +246,7 @@ The main tasks for this exercise are as follows:
 
 2. Open  **LocalDoc**, add the text  **Local Content**, and save the changes.
 
-3. Use Microsoft Edge to open  **https://login.microsoftonline.com** and sign in as **Adam@yourdomain.onmicrosoft.com** by using a password of **Pa55w.rd**.
+3. Use Microsoft Edge to open  [**https://portal.office.com**](https://portal.office.com) and sign in as **Adam@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** by using a password of **Pa55w.rd**.
 
 4. Browse to  **OneDrive** and edit **LocalDoc.docx** in the browser.
 
@@ -281,7 +280,7 @@ The main tasks for this exercise are as follows:
 
 2. Open  **Version 2.0** of the file.
 
-3. When prompted sign in as  **Adam@yourdomain.onmicrosoft.com** by using a password of **Pa55w.rd**.
+3. When prompted sign in as  **Adam@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** by using a password of **Pa55w.rd**.
 
 4. Verify that this version contains  **Cloud** and does not contain **Local**.
 
@@ -305,9 +304,9 @@ The main tasks for this exercise are as follows:
 
 2. Use the  **Share** dialog box for **LocalDoc.docx** to **Manage Access** and verify the permissions assigned to **Abbi Skinner**.
 
-3. Sign out, and then sign in as  **Adatum\Abbi** by using a password of **Pa55w.rd**.
+3. Sign out, and then sign in as  **Adatum\\Abbi** by using a password of **Pa55w.rd**.
 
-4. Use Microsoft Edge to open  **https://login.microsoftonline.com**, and then sign in as  **Abbi@yourdomain.onmicrosoft.com** by using a password of **Pa55w.rd**.
+4. Use Microsoft Edge to open  [**https://portal.office.com**](https://portal.office.com), and then sign in as  **Abbi@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** by using a password of **Pa55w.rd**.
 
 5. In  **OneDrive**, in  **Shared with me**, edit  **LocalDoc**, and then add a new line.
 
@@ -317,9 +316,9 @@ The main tasks for this exercise are as follows:
 
 #### Task 7: Disable external sharing for all users
   
-1. On  **LON-CL2**, sign in as  **Adatum\Administrator** by using a password of **Pa55w.rd**.
+1. On  **LON-CL2**, sign in as  **Adatum\\Administrator** by using a password of **Pa55w.rd**.
 
-2. Use Microsoft Edge to open  **https://login.microsoftonline.com**, and then sign in as  **GAdmin@yourtenant.onmicrosoft.com** by using your password.
+2. Use Microsoft Edge to open  [**https://portal.office.com**](https://portal.office.com), and then sign in as  **GAdmin@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** by using your password.
 
 3. Go to the Admin center, view the properties of  **Adam Hobbs**, and then view the  **OneDrive Settings**.
 
@@ -381,12 +380,11 @@ Virtual machines:
 
 -  **20697-2C-LON-CL1**
 
+-  **MT17B-WS2016-NAT**
 
-  **MT17B-WS2016-NAT**
+User name:  **Adatum\\Administrator** and **Adatum\\Adam**.
 
- User name:  **Adatum\Administrator** and **Adatum\Adam**.
-
- Password:  **Pa55w.rd**
+Password:  **Pa55w.rd**
 
  For this lab, you will use the available virtual machine environment. Before you begin the lab, you must complete the following steps:
 
@@ -397,8 +395,10 @@ Virtual machines:
 3. In the  **Actions** pane, click **Connect**. Wait until the virtual machine starts. 
 
 4. Sign in using the following credentials: 
-User name:  **Adatum**\ **Administrator**
-Password:  **Pa55w.rd**
+
+- User name:  **Adatum**\\ **Administrator**
+
+- Password:  **Pa55w.rd**
 
 5. Repeat steps 2−4 for  **20697-2C-LON-SVR1**.
 
@@ -436,7 +436,7 @@ The main tasks for this exercise are as follows:
 
 2.  **Restart the destination server automatically if required**
 
-3. After LON-SVR1 restarts, sign-in as  **Adatum\Administrator** by using a password of **Pa55w.rd**.
+3. After LON-SVR1 restarts, sign-in as  **Adatum\\Administrator** by using a password of **Pa55w.rd**.
 
 4. Open  **Server Manager** and wait for the installation to continue and until all tasks are successful.
 
@@ -444,18 +444,17 @@ The main tasks for this exercise are as follows:
 
 #### Task 2: Create a session collection
   
-1. On  **LON-SVR1**, use Server Manager ** **to remove  **QuickSessionCollection**.
+1. On  **LON-SVR1**, use Server Manager to remove  **QuickSessionCollection**.
 
 2. Create a new session collection with the following configuration:
 
+  - Name: **RemoteApp Collection**
 
-  - Name: ** RemoteApp Collection**
+  - RD Session Host Server: **LON-SVR1.Adatum.com**
 
-  - RD Session Host Server: ** LON-SVR1.Adatum.com**
+  - User Groups: **ADATUM\\Domain Users**
 
-  - User Groups: ** ADATUM\Domain Users**
-
-  - User Profile Disks: ** **Not enabled
+  - User Profile Disks: **Not enabled**
 
 
 
@@ -465,12 +464,12 @@ The main tasks for this exercise are as follows:
 
 2. In  **RemoteApp Collection**, publish the following RemoteApp programs:
 
-
 -  **Calculator**
 
 -  **Paint**
 
 -  **WordPad**
+
 
 
 #### Task 4: Create a trusted certificate
@@ -482,22 +481,22 @@ The main tasks for this exercise are as follows:
   - Enrollment policy:  **Active Directory Enrollment Policy**
 
   - Template:  **Adatum Web Server**
-Subject type:  **Common name**
 
-Subject value:  **lon-svr1.adatum.com**
+  - Subject type:  **Common name**
 
-Alternative name type:  **DNS**
+  - Subject value:  **lon-svr1.adatum.com**
 
-Alternative name value:  **lon-svr1.adatum.com**
+  - Alternative name type:  **DNS**
+
+  - Alternative name value:  **lon-svr1.adatum.com**
 
 3.  **Make private key exportable**
 
 4. Export the  **lon-svr1.adatum.com** certificate issued by **AdatumCA** by using the following settings:
 
-
   -  **Export the private key**
 
-  - File name:  **C:\cert.pfx**
+  - File name:  **C:\\cert.pfx**
 
   - Password:  **Pa55w.rd**
 
@@ -507,15 +506,17 @@ Alternative name value:  **lon-svr1.adatum.com**
   
 1. On  **LON-SVR1**, use Server Manager to edit the deployment properties in the  **COLLECTIONS** area.
 
-2. Use  **C:\cert.pfx** to add certificates for the following role services:
+2. Use  **C:\\cert.pfx** to add certificates for the following role services:
 
   -  **RD Connection Broker - Enable Single Sign On**
 
   -  **RD Connection Broker - Publishing**
 
-- **RD Web Access**
+  -  **RD Web Access**
+
 
 >  **Result**: After completing this exercise, you will have deployed RemoteApp programs.
+
 
 
 ## Exercise 2: Accessing published RemoteApp programs
@@ -542,11 +543,11 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-CL1**, use Microsoft Edge to open  **https://lon-svr1.adatum.com/rdweb**.
 
-2. Sign in as  **Adatum\Adam** by using a password of **Pa55w.rd**.
+2. Sign in as  **Adatum\\Adam** by using a password of **Pa55w.rd**.
 
 3. Open  **Paint**, and then select  **Don’t ask me again for remote connections from this publisher**.
 
-4. When you receive a prompt, sign in as  **Adatum\Adam** by using a password of **Pa55w.rd**.
+4. When you receive a prompt, sign in as  **Adatum\\Adam** by using a password of **Pa55w.rd**.
 
 
 
@@ -556,11 +557,11 @@ The main tasks for this exercise are as follows:
 
 2. Create a new Group Policy object named  **RDS SSO** and link it to **Adatum.com**.
 
-3. Edit  **RDS SSO** and browse to **Computer Configuration\Policies\Administrative Templates\System\Credentials Delegation**.
+3. Edit  **RDS SSO** and browse to **Computer Configuration\\Policies\\Administrative Templates\\System\\Credentials Delegation**.
 
 4. Enable  **Allow delegating default credentials** and add **TERMSRV/lon-svr1.adatum.com** to the list.
 
-5. To apply the new Group Policy setting, restart  **LON-CL1**, and then sign in as  **Adatum\Adam** by using a password of **Pa55w.rd**
+5. To apply the new Group Policy setting, restart  **LON-CL1**, and then sign in as  **Adatum\\Adam** by using a password of **Pa55w.rd**
 
 
 
@@ -568,7 +569,7 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-CL1**, use Microsoft Edge to open  **https://lon-svr1.adatum.com/rdweb**.
 
-2. Sign in as  **Adatum\Adam** by using a password of **Pa55w.rd**.
+2. Sign in as  **Adatum\\Adam** by using a password of **Pa55w.rd**.
 
 3. Open  **Paint**.
 
@@ -580,9 +581,9 @@ The main tasks for this exercise are as follows:
 
 2. Search for  **remoteapp**, select  **Access RemoteApp and desktops**, and then configure the following URL:
 
-  - https://lon-svr1.adatum.com/rdweb/feed/webfeed.aspx
+  - **https://lon-svr1.adatum.com/rdweb/feed/webfeed.aspx**
 
-3. When prompted, sign in as  **Adatum\Administrator** by using a password of **Pa55w.rd**.
+3. When prompted, sign in as  **Adatum\\Administrator** by using a password of **Pa55w.rd**.
 
 4. Open  **Paint (Work Resources)** from the Start menu.
 
@@ -613,6 +614,8 @@ Why is it important to use a trusted certificate for RemoteApp?
 **Question** 
 How does the user experience differ when SSO is enabled for RemoteApp programs?
 
+
+##  
 
 
 ©2016 Microsoft Corporation. All rights reserved.

--- a/Instructions/206972C_LAB_11.md
+++ b/Instructions/206972C_LAB_11.md
@@ -1,4 +1,4 @@
-# Module 11: Configuring and managing Client Hyper-V
+﻿# Module 11: Configuring and managing Client Hyper-V
 # Lab: Configuring and managing Client Hyper-V
   
 ### Scenario
@@ -21,13 +21,13 @@
   
  Estimated Time: 50 minutes
 
-Virtual machines:  **LON-DC1**, ** LON-CL1**,  **VM1**, and  **VM2**
+Virtual machines:  **LON-DC1**, **LON-CL1**,  **VM1**, and  **VM2**
 
- Username:  **Adatum\Administrator** (LON-DC1, LON-CL1), **Administrator** (VM1)
+- Username:  **Adatum\\Administrator** (LON-DC1, LON-CL1), **Administrator** (VM1)
 
- User password:  **Pa55w.rd** ( **LON-DC1**,  **LON-CL1, VM1**)
+- User password:  **Pa55w.rd** (LON-DC1, LON-CL1, VM1)
 
- Start and sign in to  **LON-CL1**.
+Start and sign in to  **LON-CL1**.
 
  VM1 and VM2 don’t exist at this point. You will be creating them during this lab.
 
@@ -41,13 +41,11 @@ Virtual machines:  **LON-DC1**, ** LON-CL1**,  **VM1**, and  **VM2**
 
 4. Sign in by using the following credentials: 
 
-
   - User name:  **Administrator**
 
   - Password:  **Pa55w.rd**
 
   - Domain:  **Adatum**
-
 
 5. Repeat steps 2-4 for  **20697-2C-LON-CL1**.
 
@@ -73,20 +71,24 @@ You decide to demonstrate to them how to enable nested virtualization and how to
   
 1. On  **LON-CL1**, verify that no program containing the word  **Hyper-V** is installed.
 
-2. Use the  **Get-Command** cmdlet to verify that no cmdlets from the Hyper-V ** **module are currently available.
+2. Use the  **Get-Command** cmdlet to verify that no cmdlets from the Hyper-V module are currently available.
 
 3. Try to install the Hyper-V Windows feature with all components.
->  **Note:** You cannot install the Hyper-V Platform feature because **LON-CL1** does not meet the prerequisites for installing Client Hyper-V.
+
+    >  **Note:** You cannot install the Hyper-V Platform feature because **LON-CL1** does not meet the prerequisites for installing Client Hyper-V.
+
 4. On the physical host computer, enable nested virtualization for  **LON-CL1** by running the following Windows PowerShell command:
 
   ```
-  Set-VMProcessor 20697-2C-LON-CL1 –ExposeVirtualizationExtensions $True
+  Set-VMProcessor 20697-2C-LON-CL1 -ExposeVirtualizationExtensions $True
   ```
 
+
 >  **Note:** You will get an error because **LON-CL1** is running and you can enable nested virtualization only if the VM is turned off.
+
 5. Shut down  **LON-CL1**, and then enable nested virtualization for  **LON-CL1**.
 
-6. Configure  **LON-CL1** with 4096 MB of memory.
+6. Configure  **LON-CL1** with **4096 MB** of memory.
 
 7. Enable MAC address spoofing for the  **LON-CL1** network adapter.
 
@@ -94,16 +96,17 @@ You decide to demonstrate to them how to enable nested virtualization and how to
 
 #### Task 2: Install Client Hyper-V
   
-1. Start  **LON-CL1** and then sign in as **Adatum\Administrator** using **Pa55w.rd** as the password.
+1. Start  **LON-CL1** and then sign in as **Adatum\\Administrator** using **Pa55w.rd** as the password.
 
 2. Install the Hyper-V Windows feature with all components, and restart  **LON-CL1** when needed.
 
-3. Sign in to  **LON-CL1** as **Adatum\Administrator** using **Pa55w.rd** as the password.
+3. Sign in to  **LON-CL1** as **Adatum\\Administrator** using **Pa55w.rd** as the password.
 
-4. Use the  **Get-Command** cmdlet to verify that many cmdlets from the Hyper-V ** **module are now available.
+4. Use the  **Get-Command** cmdlet to verify that many cmdlets from the Hyper-V module are now available.
 
 
 >  **Result**: After completing this exercise, you should have enabled nested virtualization and installed the Client Hyper-V feature.
+
 
 
 ## Exercise 2: Creating a virtual switch, a virtual hard disk, and a VM
@@ -144,50 +147,45 @@ The main tasks for this exercise are as follows:
 
 9. Try to create an additional external virtual switch named  **External Switch 2**.
 
->  **Note:** Because **LON-CL1** has a single network adapter, an error occurs. The error message states that the physical network adapter is already bound to the virtual switch, and the network adapter can be bound to only one external virtual switch.
+    >  **Note:** Because **LON-CL1** has a single network adapter, an error occurs. The error message states that the physical network adapter is already bound to the virtual switch, and the network adapter can be bound to only one external virtual switch.
+
 
 
 #### Task 2: Create virtual hard disks
   
-1. On  **LON-CL1**, ** **use Hyper-V Manager to create a new virtual hard disk with the following settings:
+1. On  **LON-CL1**, use Hyper-V Manager to create a new virtual hard disk with the following settings:
 
+- Format: **VHDX**
 
-- Format: ** VHDX**
+- Type: **Dynamically expanding**
 
-- Type: ** Dynamically expanding**
+- Name: **Dynamic.vhdx**
 
-- Name: ** Dynamic.vhdx**
+- Location:  **C:\\VMs**
 
-- Location:  **C:\VMs**
+2. Size: **100 GB**
 
+3. Use Hyper-V Manager to create a new virtual hard disk with the following settings:
 
-1. Size: ** 100 GB**
+- Format: **VHD**
 
-2. Use Hyper-V Manager to create a new virtual hard disk with the following settings:
+- Type: **Differencing**
 
+- Name: **Differencing.vhd**
 
-- Format: ** VHD**
+- Location:  **C:\\VMs**
 
-- Type: ** Differencing**
+- Parent: **E:\\Labfiles\\Mod11\\Base18A-W10-1709.vhd**
 
-- Name: ** Differencing.vhd**
+4. In Windows PowerShell, use the  **New-VHD** cmdlet to create a new virtual hard disk with the following settings:
 
-- Location:  **C:\VMs**
+- Path: **C:\\VMs\\Fixed.vhdx**
 
-- Parent: ** E:\Labfiles\Mod11\Base18A-W10-1709.vhd**
+5. Size: **1 GB**
 
+6. Type: **Fixed size**
 
-3. In Windows PowerShell, use the  **New-VHD** cmdlet to create a new virtual hard disk with the following settings:
-
-
-- Path: ** C:\VMs\Fixed.vhdx**
-
-
-4. Size: ** 1 GB**
-
-5. Type: ** Fixed size**
-
-6. In File Explorer, browse to the  **C:\VMs** folder, ** **and then confirm that  **Fixed.vhdx** allocates **1 GB** disk space, while **Dynamic.vhdx** and **Differencing.vhd** are allocated much less disk space.
+7. In File Explorer, browse to the  **C:\\VMs** folder, and then confirm that  **Fixed.vhdx** allocates **1 GB** disk space, while **Dynamic.vhdx** and **Differencing.vhd** are allocated much less disk space.
 
 
 
@@ -195,76 +193,77 @@ The main tasks for this exercise are as follows:
   
 1. On  **LON-CL1**, use Hyper-V Manager to create a new VM with the following settings:
 
+- Name: **VM1**
 
-- Name: ** VM1**
-
-- Generation: ** Generation 1**
+- Generation: **Generation 1**
 
 - Startup memory:  **1024 MB**
 
-- Use Dynamic Memory: ** Disabled**
+- Use Dynamic Memory: **Disabled**
 
 - Connection:  **External Switch**
 
-- Virtual hard disk:  **C:\VMs\Differencing.vhd**
+- Virtual hard disk:  **C:\\VMs\\Differencing.vhd**
 
+2. Start **VM1** and verify that the VM1 checkpoint has been created automatically.
 
-2. Start VM1 and verify that the VM1 checkpoint has been created automatically.
+3. While **VM1** is running, add the following two virtual hard disks to its SCSI controller:
 
-3. While VM1 is running, add the following two virtual hard disks to its SCSI controller:
+  -  **C:\\VMs\\Fixed.vhdx**
 
-  -  **C:\VMs\Fixed.vhdx**
+  -  **C:\\VMs\\Dynamic.vhd**
 
-  -  **C:\VMs\Dynamic.vhd**
+4. While **VM1** is running, increase its memory to **1500 MB**.
 
-4. While VM1 is running, increase its memory to 1500 MB.
+5. Use Hyper-V Manager to create a new VM with the following settings:
 
-5. Use Hyper-V Manager ** **to create a new VM with the following settings:
+- Name: **VM2**
 
-
-- Name: ** VM2**
-
-- Generation: ** Generation 2**
-
+- Generation: **Generation 2**
 
 6. Startup Memory:  **512 MB**
 
-7. Enable the TPM for VM2.
+7. Enable the **TPM** for VM2.
 
-8. Start VM2 and verify that the VM2 checkpoint has been created automatically.
+8. Start **VM2** and verify that the VM2 checkpoint has been created automatically.
 
-9. While VM2 is running, add a network adapter to VM2 and connect it to the private switch.
+9. While **VM2** is running, add a **network adapter** to VM2 and connect it to the **private switch**.
 
-10. Turn off VM2 and verify that its automatically created checkpoint was deleted.
+10. Turn off **VM2** and verify that its automatically created checkpoint was deleted.
 
 
 
 #### Task 4: Resize virtual hard disks
   
-1. On  **LON-CL1**, connect to VM1 using a display configuration of  **800 by 600 pixels**.
+1. On  **LON-CL1**, connect to **VM1** using a display configuration of  **800 by 600 pixels**.
 
-2. On VM1, sign in as  **Admin** and use **Pa55w.rd** as the password.
+2. On **VM1**, sign in as  **Admin** and use **Pa55w.rd** as the password.
 
-3. On VM1, use Disk Management to verify that VM1 has three disks. These are the differencing, fixed size, and dynamically expanding disks that you created earlier in the lab.
+3. On **VM1**, use Disk Management to verify that VM1 has three disks. These are the differencing, fixed size, and dynamically expanding disks that you created earlier in the lab.
 
-4. Create simple volumes with the maximum size possible on Disk 1 and Disk 2, and format them as NTFS disks.
+4. Create simple volumes with the maximum size possible on **Disk 1** and **Disk 2**, and format them as **NTFS** disks.
 
-5. Verify that the volume on Disk 1 has a size of 1 GB, the volume on Disk 2 has a size of 100 GB, and there is no unallocated space on either of those disks.
+5. Verify that the volume on Disk 1 has a size of **1 GB**, the volume on Disk 2 has a size of **100 GB**, and there is no unallocated space on either of those disks.
 
-6. On  **LON-CL1**, use the following  **Resize-VHD** cmdlets to increase Disk 1 to 2 GB, and Disk 2 to 150 GB:
+6. On  **LON-CL1**, use the following  **Resize-VHD** cmdlets to increase Disk 1 to **2 GB**, and Disk 2 to **150 GB**:
 
   ```
-  Resize-VHD C:\VMs\Fixed.vhdx –SizeBytes 2GB 
-Resize-VHD C:\VMs\Dynamic.vhdx –SizeBytes 150GB
+  Resize-VHD C:\VMs\Fixed.vhdx -SizeBytes 2GB
+  ```
+
+  ```
+  Resize-VHD C:\VMs\Dynamic.vhdx -SizeBytes 150GB
   ```
 
 7. On VM1, verify that 1 GB of unallocated space is added to Disk 1 and 50 GB of unallocated space is added to Disk 2.
 
-8. Extend volume E: to the whole of Disk 1.
+8. **Extend** volume E: to the whole of Disk 1.
 
 9. On  **LON-CL1**, use File Explorer to verify the sizes of Fixed.vhdx, Dynamic.vhdx, and Differencing.vhd virtual hard disks.
 
->  **Note:** You extended Fixed.vhdx to 2 GB. The Dynamic.vhdx size has also increased, although it is considerably smaller than 150 GB. The Differencing.vhd size has also increased because new data was written to it.
+    >  **Note:** You extended Fixed.vhdx to 2 GB. The Dynamic.vhdx size has also increased, although it is considerably smaller than 150 GB. The Differencing.vhd size has also increased because new data was written to it.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have created different types of virtual switches, virtual hard disks, and VMs.
 
@@ -287,13 +286,13 @@ You decide to demonstrate to the team how to use checkpoints and explain what th
 
 #### Task 1: Configure Integration Services
   
-1. On ** **VM1, use the Services window to verify that the Hyper-V Time Synchronization Service is running, and that the Hyper-V Guest Service Interface is not.
+1. On VM1, use the Services window to verify that the Hyper-V Time Synchronization Service is running, and that the Hyper-V Guest Service Interface is not.
 
 2. Use the  **Get-Date** cmdlet to verify the local time, and use the **Set-Date** cmdlet to set the time to **11:00**.
 
 3. Use the  **Get-Date** cmdlet to verify the local time again, and then confirm that it was set back automatically to its previous value. This change occurred because Integration Services automatically synchronizes VM time with the time on the Hyper-V host.
 
-4. On volume E:, create a file named  **File1.txt** that contains your name.
+4. On volume **E:**, create a file named  **File1.txt** that contains your name.
 
 5. On  **LON-CL1**, try to copy File1.txt from  **LON-CL1** to VM1 by using the following **Copy-VMFile** cmdlet:
 
@@ -301,8 +300,10 @@ You decide to demonstrate to the team how to use checkpoints and explain what th
   Copy-VMFile VM1 -SourcePath E:\File1.txt -DestinationPath C:\ -FileSource Host
   ```
 
+
 >  **Note:** You will get an error because the Guest Service Interface is not running in VM1.
-6. On ** LON-CL1**, use Hyper-V Manager to disable the Time synchronization and enable Guest services integration services for VM1. 
+
+6. On **LON-CL1**, use Hyper-V Manager to disable the Time synchronization and enable Guest services integration services for VM1. 
 
 7. On VM1, use the Services console to verify that the Hyper-V Time Synchronization Service is not running, and that the Hyper-V Guest Service Interface is running.
 
@@ -310,27 +311,27 @@ You decide to demonstrate to the team how to use checkpoints and explain what th
 
 9. Verify that  **File1.txt** does not exist on drive C.
 
-10. On ** LON-CL1**, use the following  **Copy-VMFile** cmdlet to copy the file **E:\File1.txt** to the root of the C drive in **VM1**: 
+10. On **LON-CL1**, use the following  **Copy-VMFile** cmdlet to copy the file **E:\\File1.txt** to the root of the C drive in **VM1**: 
 
   ```
-  Copy- VMFile VM1 -SourcePath E:\File1.txt -DestinationPath C:\ -FileSource Host
+  Copy-VMFile VM1 -SourcePath E:\File1.txt -DestinationPath C:\ -FileSource Host
   ```
 
-11. On VM1, verify that File1.txt ** **now exists on drive C.
+11. On VM1, verify that File1.txt now exists on drive C.
 
-12. View content of C:\File1.txt, and verify that it contains your name.
+12. View content of C:\\File1.txt, and verify that it contains your name.
 
 
 
 #### Task 2: Work with checkpoints
   
-1. On  **LON-CL1**, use Hyper-V Manager to verify that ** **VM1 is using the  **Fixed.vhdx** virtual hard disk and that it is configured to use standard checkpoints.
+1. On  **LON-CL1**, use Hyper-V Manager to verify that VM1 is using the  **Fixed.vhdx** virtual hard disk and that it is configured to use standard checkpoints.
 
 2. Create a checkpoint for  **LON-VM1**, and verify that it displays in Hyper-V Manager.
 
 3. On VM1, create a folder named  **Folder1** on the desktop.
 
-4. Create a checkpoint for VM1, ** **and name it  **Folder1**. 
+4. Create a checkpoint for VM1, and name it  **Folder1**. 
 
 5. On  **LON-CL1**, use Hyper-V Manager to verify that VM1 is now using a virtual hard disk whose name starts with  _Fixed_ and it has a GUID in its name.
 
@@ -338,23 +339,27 @@ You decide to demonstrate to the team how to use checkpoints and explain what th
 
 7. On VM1, on the desktop, create a folder named  **Folder2**.
 
-8. Create a checkpoint for VM1 ** **and name it  **Folder2**. 
+8. Create a checkpoint for VM1 and name it  **Folder2**. 
 
 9. On  **LON-CL1**, use Hyper-V Manager to verify that VM1 has four checkpoints.
 
 10. Apply a checkpoint named  **Folder1** to VM1.
 
-11. On VM1, sign in as  **Admin**, ** **and use  **Pa55w.rd** as the password.
+11. On VM1, sign in as  **Admin**, and use  **Pa55w.rd** as the password.
 
 12. Verify that only  **Folder1** displays on the desktop, that Windows PowerShell is running, and that you can view the cmdlets that you used previously in the Windows PowerShell window.
->  **Note:** You have just applied a standard checkpoint, which includes memory content.
-13. On  **LON-CL1**, apply a checkpoint named  **Folder2** to VM1.
 
-14. Start VM1, and then sign in as  **Admin** using **Pa55w.rd** as the password.
+    >  **Note:** You have just applied a standard checkpoint, which includes memory content.
+
+13. On  **LON-CL1**, apply a checkpoint named  **Folder2** to **VM1**.
+
+14. Start **VM1**, and then sign in as  **Admin** using **Pa55w.rd** as the password.
 
 15. On VM1, verify that the Folder1 and Folder2 folders are available on the desktop. Also verify that no running program displays on the taskbar. 
 
->  **Note:** You applied a production checkpoint. Because a production checkpoint does not include memory content, the VM must go through the startup process when you apply a production checkpoint.
+    >  **Note:** You applied a production checkpoint. Because a production checkpoint does not include memory content, the VM must go through the startup process when you apply a production checkpoint.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have configured Integration Services, and created and applied checkpoints.
 
@@ -368,6 +373,8 @@ In the lab, you created a private virtual switch to connect to the VM. Would a p
 **Question** 
 Can you use Hyper-V Manager to shrink a virtual hard disk in VHDX format while it is in use?
 
+
+##  
 
 
 ©2016 Microsoft Corporation. All rights reserved.

--- a/Instructions/206972C_LAB_AK_01.md
+++ b/Instructions/206972C_LAB_AK_01.md
@@ -1,7 +1,8 @@
-# Lab Answer Key:  Module 1: Managing PCs and devices in an enterprise environment
+﻿# Lab Answer Key:  Module 1: Managing PCs and devices in an enterprise environment
 # Lab: Planning for Windows 10 and device management in an enterprise
   
 ## Exercise 1: Read the scenario
+
   >  **Result**: After reading the scenario, students will have an understanding of the Adatum environment and requirements.
 
 

--- a/Instructions/206972C_LAB_AK_02.md
+++ b/Instructions/206972C_LAB_AK_02.md
@@ -306,7 +306,7 @@ For the local administrator account, provide the following values in the text bo
 
 
 ```
-dism /Capture-Image /ImageFile:g:\Reference.wim /CaptureDir:c:\ /name:”Reference Image”
+dism /Capture-Image /ImageFile:g:\Reference.wim /CaptureDir:c:\ /name:"Reference Image"
 ```
 
 >  **Note:** You can continue with the lab while the capture is in progress.
@@ -350,7 +350,7 @@ dism /Get-WimInfo /WimFile:d:\sources\install.wim /index:1
 1. On  **LON-CL1**, in the  **Windows PowerShell** window, create a Windows image file that contains the contents of the **C:\\Windows\\INF** folder by typing the following cmdlet, and then pressing Enter:
 
   ```
-  New-WindowsImage –ImagePath C:\Image.wim –CapturePath C:\Windows\INF –Name “First image”
+  New-WindowsImage –ImagePath C:\Image.wim –CapturePath C:\Windows\INF –Name "First image"
   ```
 
 2. On the taskbar, select  **File Explorer**. In the navigation pane, expand  **Local Disk (C:)**, and then select  **Windows**. In the details pane, right-click the  **INF** folder, and then select **Properties**. Note the folder size, and then select  **OK**.
@@ -367,7 +367,7 @@ dism /Get-WimInfo /WimFile:d:\sources\install.wim /index:1
 4. To capture the same content to a second image in the same Windows image file, type the following cmdlet, and then press Enter: 
 
   ```
-  Add-WindowsImage –ImagePath C:\Image.wim –CapturePath C:\Windows\INF –Name “Second image”
+  Add-WindowsImage –ImagePath C:\Image.wim –CapturePath C:\Windows\INF –Name "Second image"
   ```
 
 >  **Note:** Note that the second image, which has the same content as the first image, is adds much faster.

--- a/Instructions/206972C_LAB_AK_02.md
+++ b/Instructions/206972C_LAB_AK_02.md
@@ -350,7 +350,7 @@ dism /Get-WimInfo /WimFile:d:\sources\install.wim /index:1
 1. On  **LON-CL1**, in the  **Windows PowerShell** window, create a Windows image file that contains the contents of the **C:\\Windows\\INF** folder by typing the following cmdlet, and then pressing Enter:
 
   ```
-  New-WindowsImage –ImagePath C:\Image.wim –CapturePath C:\Windows\INF –Name "First image"
+  New-WindowsImage -ImagePath C:\Image.wim -CapturePath C:\Windows\INF -Name "First image"
   ```
 
 2. On the taskbar, select  **File Explorer**. In the navigation pane, expand  **Local Disk (C:)**, and then select  **Windows**. In the details pane, right-click the  **INF** folder, and then select **Properties**. Note the folder size, and then select  **OK**.
@@ -367,7 +367,7 @@ dism /Get-WimInfo /WimFile:d:\sources\install.wim /index:1
 4. To capture the same content to a second image in the same Windows image file, type the following cmdlet, and then press Enter: 
 
   ```
-  Add-WindowsImage –ImagePath C:\Image.wim –CapturePath C:\Windows\INF –Name "Second image"
+  Add-WindowsImage -ImagePath C:\Image.wim -CapturePath C:\Windows\INF -Name "Second image"
   ```
 
 >  **Note:** Note that the second image, which has the same content as the first image, is adds much faster.
@@ -386,7 +386,7 @@ dism /Get-WimInfo /WimFile:d:\sources\install.wim /index:1
 
 
 ```
-Get-WindowsImage –ImagePath C:\Image.wim
+Get-WindowsImage -ImagePath C:\Image.wim
 ```
 
 

--- a/Instructions/206972C_LAB_AK_02.md
+++ b/Instructions/206972C_LAB_AK_02.md
@@ -204,7 +204,7 @@ For the local administrator account, provide the following values in the text bo
 
 9. In the  **Open** dialog box, in the navigation pane, select **Allfiles (D:)**. In the details pane, double-click  **Program Files**, double-click  **Microsoft Learning**, double-click  **20697-2**, double-click  **Drives**, select  **Transfer.vfd**, and then select  **Open**.
 
-10. On  **LON-CL3**, on the taskbar, select  **Start**, ** **and then select the  **Settings** app.
+10. On  **LON-CL3**, on the taskbar, select  **Start**, and then select the  **Settings** app.
 
 11. In the Settings app, select  **Accounts**, select the  **Access work or school** tab, select **Add or remove a provisioning package**, select  **Add a package**, select  **Marketing Computer.ppkg**, and then select **Add**.
 

--- a/Instructions/206972C_LAB_AK_02.md
+++ b/Instructions/206972C_LAB_AK_02.md
@@ -1,4 +1,4 @@
-# Lab Answer Key:  Module 2: Traditional Windows 10 deployment in an enterprise
+﻿# Lab Answer Key:  Module 2: Traditional Windows 10 deployment in an enterprise
 # Lab: Deploying Windows 10 by using Windows ADK tools
   
 ## Exercise 1: Creating an answer file and installing Windows 10 on a reference computer
@@ -11,7 +11,7 @@
 
 3. In the  **Settings for 20697-2C-LON-CL1** window, in the navigation pane, select **Diskette Drive**.
 
-4. In the details pane, select  **Virtual floppy disk (.vfd) file**, browse to  **D:\Program Files\Microsoft Learning\20697-2\Drives**, double-click  **VFloppy.vfd**, and then select  **OK**.
+4. In the details pane, select  **Virtual floppy disk (.vfd) file**, browse to  **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives**, double-click  **VFloppy.vfd**, and then select  **OK**.
 
 
 
@@ -21,17 +21,17 @@
 
 2. In File Explorer, in the navigation pane, click  **This PC**. 
 
-3. In the details pane, right-click  **Floppy Disk Drive (A:)**, click  **Format**, click  **Start**, click  **OK** twice, click **Close**, ** **and then close File Explorer.
+3. In the details pane, right-click  **Floppy Disk Drive (A:)**, click  **Format**, click  **Start**, click  **OK** twice, click **Close**, and then close File Explorer.
 
 4. On the taskbar, select  **Start**, type  **image**, and then select  **Windows System Image Manager**.
 
 5. In Windows System Image Manager (Windows SIM), select  **File**, and then select  **Open Answer File**.
 
-6. In the  **Open** dialog box, in the navigation pane, browse to **E:\Labfiles\Mod02**, select  **Autounattend.xml**, and then select  **Open**. Notice that the  **Components** and **Packages** nodes appear in the Windows Image ** **pane, and the  **Answer File** pane is populated with the installation passes.
+6. In the  **Open** dialog box, in the navigation pane, browse to **E:\\Labfiles\\Mod02**, select  **Autounattend.xml**, and then select  **Open**. Notice that the  **Components** and **Packages** nodes appear in the **Windows Image** pane, and the  **Answer File** pane is populated with the installation passes.
 
-7. In the  **Answer File** pane, expand **1 windowsPE**, ** **and then select  **amd64_Microsoft-Windows-International-Core-WinPE_neutral**. In the  **amd64_Microsoft-Windows-International-Core-WinPE Properties** pane, verify that **InputLocale**, ** SystemLocale**, ** UILanguage**, ** **and  **UserLocale** have **en-US** values.
+7. In the  **Answer File** pane, expand **1 windowsPE**, and then select  **amd64_Microsoft-Windows-International-Core-WinPE_neutral**. In the  **amd64_Microsoft-Windows-International-Core-WinPE Properties** pane, verify that **InputLocale**, **SystemLocale**, **UILanguage**, and **UserLocale** have **en-US** values.
 
-8. In the  **Answer File** pane, expand **amd64_Microsoft-Windows-Setup_neutral**, expand  **DiskConfiguration**, expand  **Disk[DiskID=”0”]**, expand  **CreatePartitions**, ** **and then expand  **ModifyPartitions**. 
+8. In the  **Answer File** pane, expand **amd64_Microsoft-Windows-Setup_neutral**, expand  **DiskConfiguration**, expand  **Disk[DiskID=”0”]**, expand  **CreatePartitions**, and then expand  **ModifyPartitions**. 
 
 9. Select  **CreatePartition[Order=”1”]**. In the  **CreatePartition[Order=”1”] Properties** pane, verify that the **Extend** setting has a value of **True**, the  **Order** setting has a value of **1**, and the  **Type** setting has a value of **Primary**.
 
@@ -41,11 +41,11 @@
 
 12. In the  **ModifyPartition[Order=”1”] Properties** pane, select the **Label** text box, and then type **Windows 10**.
 
-13. In the  **Answer File** pane, expand **ImageInstall**, expand  **OSImage**, ** **and then select  **InstallTo**. ** **In the  **InstallTo Properties** pane, verify that the **DiskID** setting has a value of **0** and the **PartitionID** setting has a value of **1**.
+13. In the  **Answer File** pane, expand **ImageInstall**, expand  **OSImage**, and then select  **InstallTo**. In the  **InstallTo Properties** pane, verify that the **DiskID** setting has a value of **0** and the **PartitionID** setting has a value of **1**.
 
-14. In the  **Answer File** pane, select **UserData**. ** **In the  **UserData Properties** pane, select the **FullName** text box, and then type your name. Select the **Organization** text box, and then type your organization’s name.
+14. In the  **Answer File** pane, select **UserData**. In the  **UserData Properties** pane, select the **FullName** text box, and then type your name. Select the **Organization** text box, and then type your organization’s name.
 
-15. In the  **Answer File** pane, expand **7 oobeSystem**, ** **expand  **amd64_Microsoft-Windows-Shell-Setup_neutral**, expand  **UserAccounts**, expand  **LocalAccounts**, ** **and then select  **LocalAccount[Name=”Admin”]**. In the  **LocalAccount[Name=”Admin”] Properties** pane, verify the values of the following settings:
+15. In the  **Answer File** pane, expand **7 oobeSystem**, expand  **amd64_Microsoft-Windows-Shell-Setup_neutral**, expand  **UserAccounts**, expand  **LocalAccounts**, and then select  **LocalAccount[Name=”Admin”]**. In the  **LocalAccount[Name=”Admin”] Properties** pane, verify the values of the following settings:
 
   - DisplayName:  **Admin**
 
@@ -55,9 +55,9 @@
 
 16. In the  **LocalAccount[Name=”Admin”] Properties** pane, select the **Description** text box, and then type **My local Admin**.
 
-17. In Windows SIM, select  **File**, select  **Save Answer File**, ** **and then close Windows SIM.
+17. In Windows SIM, select  **File**, select  **Save Answer File**, and then close Windows SIM.
 
-18. Open  **File Explorer** and browse to **E:\Labfiles\Mod02**.
+18. Open  **File Explorer** and browse to **E:\\Labfiles\\Mod02**.
 
 19. Right-click  **Autounattend.xml** and then select **Copy**.
 
@@ -83,11 +83,11 @@
 
 2. In the  **Settings for20697-2C-LON-CL5** window, select **Diskette Drive**.
 
-3. In the details pane, select  **Virtual floppy disk (.vfd) file**, browse to  **D:\Program Files\Microsoft Learning\20697-2\Drives**, and then double-click  **VFloppy.vfd**.
+3. In the details pane, select  **Virtual floppy disk (.vfd) file**, browse to  **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives**, and then double-click  **VFloppy.vfd**.
 
 4. In the  **Settings for20697-2C-LON-CL5** window, select **DVD Drive**.
 
-5. In the details pane, select  **Image file**, browse to  **D:\Program Files\Microsoft Learning\20697-2\Drives**, double-click  **Win10_1709_Eval.iso**, and then select  **OK**.
+5. In the details pane, select  **Image file**, browse to  **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives**, double-click  **Win10_1709_Eval.iso**, and then select  **OK**.
 
 6. In  **Hyper-V Manager**, right-click  **20697-2C-LON-CL5**, and then select  **Connect**.
 
@@ -103,7 +103,7 @@
   
 #### Task 1: Review the current computer settings
   
-1. On  **LON-DC1**, on the taskbar, select  **Start**, ** **and then select  **Server Manager**.
+1. On  **LON-DC1**, on the taskbar, select  **Start**, and then select  **Server Manager**.
 
 2. In  **Server Manager**, select  **Tools**, and then select  **Active Directory Users and Computers**.
 
@@ -133,9 +133,9 @@
 
 2. In the  **Settings for 20697-2C-LON-CL1** window, in the navigation pane, select **Diskette Drive**.
 
-3. In the details pane, select  **Virtual floppy disk (.vfd) file**, browse to  **D:\Program Files\Microsoft Learning\20697-2\Drives**, double-click  **Transfer.vfd**, and then select  **OK**.
+3. In the details pane, select  **Virtual floppy disk (.vfd) file**, browse to  **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives**, double-click  **Transfer.vfd**, and then select  **OK**.
 
-4. On  **LON-CL1**, on the taskbar, select  **Start**, type  **designer**, ** **and then select  **Windows Imaging and Configuration Designer**.
+4. On  **LON-CL1**, on the taskbar, select  **Start**, type  **designer**, and then select  **Windows Imaging and Configuration Designer**.
 
 5. After Windows Configuration Designer opens, select the  **Provision desktop devices** tile.
 
@@ -147,7 +147,7 @@
 
   - Domain Name:  **Adatum.com**
 
-  - Username:  **Adatum\Ada**
+  - Username:  **Adatum\\Ada**
 
   - User password:  **Pa55w.rd**
 For the local administrator account, provide the following values in the text boxes:
@@ -178,9 +178,9 @@ For the local administrator account, provide the following values in the text bo
 
 19. On the  **Select where to save the provisioning package** page, select **Browse**, select  **This PC**, and then double-click  **Floppy Disk Drive (A:)**.
 
-20. In the  **File name** text box, type **Marketing Computer**, select  **Save**, select  **Next**, select  **Build**, ** **and then select  **Finish**.
+20. In the  **File name** text box, type **Marketing Computer**, select  **Save**, select  **Next**, select  **Build**, and then select  **Finish**.
 
-21. In the  **20697-2C-LON-CL1** window, select **Media**, select  **Diskette Drive**, ** **and then select  **Eject Transfer.vfd**.
+21. In the  **20697-2C-LON-CL1** window, select **Media**, select  **Diskette Drive**, and then select  **Eject Transfer.vfd**.
 
 
 
@@ -188,25 +188,25 @@ For the local administrator account, provide the following values in the text bo
   
 1. In the  **20697-2C-LON-CL4** window, select **Media**, select  **Diskette Drive**, and then select  **Insert Disk**.
 
-2. In the  **Open** dialog box, in the navigation pane, select **Allfiles (D:)**. In the details pane, double-click  **Program Files**, double-click  **Microsoft Learning**, double-click  **20697-2**, double-click  **Drives**, select  **Transfer.vfd**, ** **and then select  **Open**.
+2. In the  **Open** dialog box, in the navigation pane, select **Allfiles (D:)**. In the details pane, double-click  **Program Files**, double-click  **Microsoft Learning**, double-click  **20697-2**, double-click  **Drives**, select  **Transfer.vfd**, and then select  **Open**.
 
 3. On  **LON-CL4**, on the taskbar, select the  **File Explorer** icon.
 
 4. In File Explorer, in the navigation pane, select  **This PC**. In the details pane, double-click  **Floppy Disk Drive (A:)**, and then double-click  **Marketing Computer.ppkg**.
 
-5. In the  **User Account Control** dialog box, select **Yes**, ** **read the note on the  **Is this package from a source you trust** page, and then select **Yes, add it**.
+5. In the  **User Account Control** dialog box, select **Yes**, read the note on the  **Is this package from a source you trust** page, and then select **Yes, add it**.
 
 6. Wait until  **LON-CL4** restarts, and then sign in as **Admin** with the password **Pa55w.rd**.
 
-7. In the  **20697-2C-LON-CL4** window, select **Media**, select  **Diskette Drive**, ** **and then select  **Eject Transfer.vfd**.
+7. In the  **20697-2C-LON-CL4** window, select **Media**, select  **Diskette Drive**, and then select  **Eject Transfer.vfd**.
 
 8. In the  **20697-2C-LON-CL3** window, select **Media**, select  **Diskette Drive**, and then select  **Insert Disk**.
 
-9. In the  **Open** dialog box, in the navigation pane, select **Allfiles (D:)**. In the details pane, double-click  **Program Files**, double-click  **Microsoft Learning**, double-click  **20697-2**, double-click  **Drives**, select  **Transfer.vfd**, ** **and then select  **Open**.
+9. In the  **Open** dialog box, in the navigation pane, select **Allfiles (D:)**. In the details pane, double-click  **Program Files**, double-click  **Microsoft Learning**, double-click  **20697-2**, double-click  **Drives**, select  **Transfer.vfd**, and then select  **Open**.
 
 10. On  **LON-CL3**, on the taskbar, select  **Start**, ** **and then select the  **Settings** app.
 
-11. In the Settings app, select  **Accounts**, select the  **Access work or school** tab, select **Add or remove a provisioning package**, select  **Add a package**, select  **Marketing Computer.ppkg**, and then ** **select  **Add**.
+11. In the Settings app, select  **Accounts**, select the  **Access work or school** tab, select **Add or remove a provisioning package**, select  **Add a package**, select  **Marketing Computer.ppkg**, and then select **Add**.
 
 12. In the  **User Account Control** dialog box, select **Yes**. Read the note on the  **Is this package from a source you trust** page, select **Yes, add it**, and then wait until  **LON-CL3** restarts.
 
@@ -219,10 +219,14 @@ For the local administrator account, provide the following values in the text bo
 2. In  **Server Manager**, select  **Tools**, and then select  **Active Directory Users and Computers**.
 
 3. In Active Directory Users and Computers, in the navigation pane, expand  **Adatum.com**, expand  **Marketing**, and then select  **Computers**. In the details pane, verify that two computer accounts are present, as you installed the provisioning package on two computers. The names of both computers start with  **MARKETING-** followed by three digits.
+
+
 >  **Note:** If the **Computers** organizational unit (OU) is empty, right-click the OU, and then select **Refresh**.
+
+
 4. On  **LON-CL4**, on the taskbar, select the  **File Explorer** icon.
 
-5. In File Explorer, in the navigation pane, right-click  **This PC**, ** **and then select  **Properties**. In the  **Computer name, domain, and workgroupsettings** section, verify that the computer name is **Marketing-** followed by three digits and that computer is in the **Adatum.com** domain.
+5. In File Explorer, in the navigation pane, right-click  **This PC**, and then select  **Properties**. In the  **Computer name, domain, and workgroupsettings** section, verify that the computer name is **Marketing-** followed by three digits and that computer is in the **Adatum.com** domain.
 
 6. Close the  **System** window.
 
@@ -252,14 +256,22 @@ For the local administrator account, provide the following values in the text bo
 
 4. On the taskbar, select  **File Explorer**.
 
-5. In File Explorer, in the navigation pane, expand  **This PC**, ** **and then verify that drive  **C:** is labeled **Windows 10**, as you specified in the answer file.
+5. In File Explorer, in the navigation pane, expand  **This PC**, and then verify that drive  **C:** is labeled **Windows 10**, as you specified in the answer file.
 
-6. In File Explorer, in the navigation pane, right- click  **Windows 10 (C:)**, ** **and then select  **Properties**. Verify that the volume has a capacity of  **96.6 GB**, and then select  **OK**.
+6. In File Explorer, in the navigation pane, right- click  **Windows 10 (C:)**, and then select  **Properties**. Verify that the volume has a capacity of  **96.6 GB**, and then select  **OK**.
+
+
 >  **Note:** In the answer file, you specified that the volume should have a size of 99,000 megabytes (MB). 1 gigabyte (GB) is 1,024 MB, and therefore, 96.6 GB is approximately 99,000 MB.
+
+
 7. On the taskbar, right-click  **Start**, and then select  **Computer Management**.
 
-8. In  **Computer Management**, in the navigation pane, expand  **Local Users and Groups**, select  **User**s, ** **and then in the details pane, verify that the user named  **Admin** has the description **My local Admin**, as you configured in the answer file.
+8. In  **Computer Management**, in the navigation pane, expand  **Local Users and Groups**, select  **Users**, and then in the details pane, verify that the user named  **Admin** has the description **My local Admin**, as you configured in the answer file.
+
+
 >  **Note:** You can install custom apps, such as Microsoft Office, and customize the reference computer before running the System Preparation Tool (Sysprep) and capturing the image. We will skip the customization part in this lab.
+
+
 9. On the taskbar, right-click  **Start**, select  **Windows PowerShell (Admin)**, and then select  **Yes** in the **User Account Control** dialog box.
 
 10. In the  **Administrator: Windows PowerShell** window, type the following command, and then press Enter:
@@ -268,7 +280,7 @@ For the local administrator account, provide the following values in the text bo
   C:\Windows\System32\sysprep\sysprep.exe
   ```
 
-11. In the  **System Preparation Tool 3.14** dialog box, select the **Generalize** check box, in the **Shutdown** drop-down list, select **Shutdown**, ** **and then select  **OK**.
+11. In the  **System Preparation Tool 3.14** dialog box, select the **Generalize** check box, in the **Shutdown** drop-down list, select **Shutdown**, and then select  **OK**.
 
 12. After  **LON-CL5** turns off, select **Action**, select  **Checkpoint**, type  **Generalized** in the text box, and then select **Yes**. 
 
@@ -280,11 +292,11 @@ For the local administrator account, provide the following values in the text bo
 
 2. In the  **Settings for20697-2C-LON-CL5** window, in the navigation pane, select **DVD Drive**.
 
-3. In the details pane, verify that the  **Image file** button is selected. Select **Browse**, select  **WindowsPE.iso** in the **D:\Program Files\Microsoft Learning\20697-2\Drives** folder, select **Open**, ** **and then select  **OK**.
+3. In the details pane, verify that the  **Image file** button is selected. Select **Browse**, select  **WindowsPE.iso** in the **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives** folder, select **Open**, and then select  **OK**.
 
 4. In the  **20697-2C-LON-CL5** window, on the toolbar, select the **Start** button. When **LON-CL5** starts, press any key to start the computer from the DVD media.
 
-5. In the  **Administrator: X:\Windows\system32\cmd.exe** window, type the following command, and then press Enter:
+5. In the  **Administrator: X:\\Windows\\system32\\cmd.exe** window, type the following command, and then press Enter:
 
   ```
   Net use g: \\lon-cl1\Images Pa55w.rd /user:adatum\administrator
@@ -306,10 +318,14 @@ dism /Capture-Image /ImageFile:g:\Reference.wim /CaptureDir:c:\ /name:”Referen
 
 2. In the  **Settings for20697-2C-LON-CL1** window, in the navigation pane, select **DVD Drive**.
 
-3. In the details pane, select the  **Image file** button, browse to **D:\Program Files\Microsoft Learning\20697-2\Drives**, double-click  **Win10_1709_Eval.iso**, and then select  **OK**.
+3. In the details pane, select the  **Image file** button, browse to **D:\\Program Files\\Microsoft Learning\\20697-2\\Drives**, double-click  **Win10_1709_Eval.iso**, and then select  **OK**.
 
-4. On  **LON-CL1**, in File Explorer, in the navigation pane, select  **DVD Drive (D:)**. ** **In the details pane, double-click  **sources**, right-click  **install.wim**, and then select  **Properties**. View the properties of the Windows image file, and then select  **OK**.
+4. On  **LON-CL1**, in File Explorer, in the navigation pane, select  **DVD Drive (D:)**. In the details pane, double-click  **sources**, right-click  **install.wim**, and then select  **Properties**. View the properties of the Windows image file, and then select  **OK**.
+
+
 >  **Note:** Note that the file size is 3.45 GB (3,709,075,311 bytes) and that there is another Windows image file named **Boot.wim** in the folder.
+
+
 5. On the taskbar, right-click  **Start**, and then select  **Windows PowerShell**.
 
 6. In the Windows PowerShell command-line interface, type the following command, and then press Enter to view the contents of the  **install.wim** file:
@@ -331,13 +347,13 @@ dism /Get-WimInfo /WimFile:d:\sources\install.wim /index:1
 
 #### Task 4: Capture the custom image
   
-1. On  **LON-CL1**, in the  **Windows PowerShell** window, create a Windows image file that contains the contents of the **C:\Windows\INF** folder by typing the following cmdlet, and then pressing Enter:
+1. On  **LON-CL1**, in the  **Windows PowerShell** window, create a Windows image file that contains the contents of the **C:\\Windows\\INF** folder by typing the following cmdlet, and then pressing Enter:
 
   ```
   New-WindowsImage –ImagePath C:\Image.wim –CapturePath C:\Windows\INF –Name “First image”
   ```
 
-2. On the taskbar, select  **File Explorer**. In the navigation pane, expand  **Local Disk (C:)**, and then select  **Windows**. ** **In the details pane, right-click the  **INF** folder, and then select **Properties**. Note the folder size, and then select  **OK**.
+2. On the taskbar, select  **File Explorer**. In the navigation pane, expand  **Local Disk (C:)**, and then select  **Windows**. In the details pane, right-click the  **INF** folder, and then select **Properties**. Note the folder size, and then select  **OK**.
 
 3. In the  **Windows PowerShell** window, type the following command, and then press Enter to view the size of the Windows image file:
 
@@ -346,6 +362,8 @@ dism /Get-WimInfo /WimFile:d:\sources\install.wim /index:1
   ```
 
 >  **Note:** Although the size of the **INF** folder is almost 40 MB, you will see that **image.wim** is less than 5 MB. This illustrates how effectively the initial files were compressed when they were added to the Windows image file.
+
+
 4. To capture the same content to a second image in the same Windows image file, type the following cmdlet, and then press Enter: 
 
   ```
@@ -353,6 +371,8 @@ dism /Get-WimInfo /WimFile:d:\sources\install.wim /index:1
   ```
 
 >  **Note:** Note that the second image, which has the same content as the first image, is adds much faster.
+
+
 5. Review the size of the Windows image file that now contains two images by typing the following command, and then pressing Enter:
 
   ```
@@ -360,6 +380,8 @@ dism /Get-WimInfo /WimFile:d:\sources\install.wim /index:1
   ```
 
 >  **Note:** Note that **image.wim** is only slightly larger. The Windows image file format uses a single instance store, so each file is stored only once. Because the files in both images are the same, each file is contained only once.
+
+
 6. Type the following cmdlet, and then press Enter to verify which images are in the  **image.wim** file:
 
 
@@ -371,7 +393,7 @@ Get-WindowsImage –ImagePath C:\Image.wim
 
 #### Task 5: Service and update the image
   
-1. On  **LON-CL1**, in File Explorer, view the size of the  **C:\image.wim** file, and then note when the file was last modified.
+1. On  **LON-CL1**, in File Explorer, view the size of the  **C:\\image.wim** file, and then note when the file was last modified.
 
 2. In the  **Windows PowerShell** window, type the following two commands, and then press Enter after each command. The first command creates the folder, and the second command mounts the second image in the **image.wim** Windows image file to the created folder:
 
@@ -380,9 +402,9 @@ Get-WindowsImage –ImagePath C:\Image.wim
 dism /Mount-wim /WimFile:c:\image.wim /Index:2 /MountDir:c:\mount
   ```
 
-3. In File Explorer, view the properties of the  **C:\mount** folder. Note that the size and contents of the folder are exactly the same as the contents of the **C:\Windows\INF** folder.
+3. In File Explorer, view the properties of the  **C:\\mount** folder. Note that the size and contents of the folder are exactly the same as the contents of the **C:\\Windows\\INF** folder.
 
-4. In File Explorer, browse to the  **C:\mount** folder, and then create a subfolder named **Folder1**. Select and delete the  **1394.PNF**,  **acpi.PNF**, and  **acpidev.PNF** files, and then close File Explorer.
+4. In File Explorer, browse to the  **C:\\mount** folder, and then create a subfolder named **Folder1**. Select and delete the  **1394.PNF**,  **acpi.PNF**, and  **acpidev.PNF** files, and then close File Explorer.
 
 5. In the  **Windows PowerShell** window, type the following command, and then press Enter to unmount the image:
 
@@ -423,7 +445,7 @@ dism /Get-WimInfo /WimFile:c:\image.wim /index:2
 
 3. In the  **Revert Virtual Machines** dialog box, click **Revert**.
 
-4. Repeat steps 2 and 3 for  **20697-2C-LON-CL1,20697-2C-LON-CL3, 20697-2C-LON-CL4,** and ** 20697-2C-LON-CL5.**
+4. Repeat steps 2 and 3 for  **20697-2C-LON-CL1,20697-2C-LON-CL3, 20697-2C-LON-CL4,** and **20697-2C-LON-CL5.**
 
 
 >  **Result**: After completing this exercise, you should have successfully generalized and captured an image of the reference computer. You should have also performed offline servicing of the image.

--- a/Instructions/206972C_LAB_AK_03.md
+++ b/Instructions/206972C_LAB_AK_03.md
@@ -1,4 +1,4 @@
-# Lab Answer Key:  Module 3: Managing Windows 10 sign-in and identity
+﻿# Lab Answer Key:  Module 3: Managing Windows 10 sign-in and identity
 # Lab: Extending on-premises AD DS to Azure AD
   
 ## Exercise 1: Activating a trial Azure subscription and creating an Azure AD tenant
@@ -11,10 +11,12 @@
 
 3. In the Microsoft Edge address bar, type  **login.live.com**.
 
-4. In the  **Sign in** box, look for the “No account?” text, and then select the **Create one!** link.
+4. In the  **Sign in** box, look for the “**No account?**” text, and then select the **Create one!** link.
 
 5. On the  **Create account** page, fill in the required fields with appropriate data. Create a new email address in the Outlook.com domain.
->  **Note:** Make sure that you write down the username that you chose. For example, you can choose a username in the _YourInitials-Date_@outlook.com format, for example, DJ-060815@outlook.com. We recommend that you type your working email address in the  **Alternate email address** text box.
+
+>  **Note:** Make sure that you write down the username that you chose. For example, you can choose a username in the *YourInitials-Date*@outlook.com format, for example, DJ-060815@outlook.com. We recommend that you type your working email address in the  **Alternate email address** text box.
+
 6. In the  **Create password** text box, type a password, and then select **Next**.
 
 7. On the  **Add details** page, type your first and last names, and then select **Next**.
@@ -37,7 +39,7 @@
   
 1. On  **LON-CL3**, open a new tab in the Microsoft Edge browser by selecting the plus sign ( **+**) icon.
 
-2. In Microsoft Edge, in the address bar, type  **http://aka.ms/cu92vo**, and then press Enter.
+2. In Microsoft Edge, in the address bar, type  [**http://aka.ms/cu92vo**](http://aka.ms/cu92vo), and then press Enter.
 
 3. On the  **Ready to get started** page, select **Start**.
 
@@ -54,7 +56,9 @@
 9. Wait for a few minutes until your Azure subscription has been created.
 
 10. Select  **Or get started with your Azure subscription**, and then verify that a new Azure portal opens.
->  **Note:** If an authentication error occurs, sign out, close all browser windows, and then sign in at https://portal.azure.com.
+
+>  **Note:** If an authentication error occurs, sign out, close all browser windows, and then sign in at [**https://portal.azure.com**](https://portal.azure.com).
+
 11. If necessary, in the  **Welcome to Microsoft Azure** window, click **Maybe later**.
 
 12. You can browse through the portal to see the available options, but don’t make any changes.
@@ -65,7 +69,7 @@
 
 #### Task 3: Review the default Azure AD directory settings
   
-1. On  **LON-CL3**, open Microsoft Edge, and then browse to  **https://portal.azure.com**.
+1. On  **LON-CL3**, open Microsoft Edge, and then browse to  [**https://portal.azure.com**](https://portal.azure.com).
 
 2. On the  **Sign-in** page, sign in with the Microsoft account that is associated with your Azure subscription.
 
@@ -73,7 +77,9 @@
 
 4. Read the name of the default directory above the  **Overview** link. This name is based on the email address that was used to create the tenant.
 
-5. Select  **Custom domain names**, and then read the existing name. Record the existing name because it will be required in the next exercise. The name of your domain will be based on the email address provided during creation in the &lt; _initials_&gt;&lt; _date_&gt;outlook.onmicrosoft.com format.
+5. Select  **Custom domain names**, and then read the existing name. Record the existing name because it will be required in the next exercise. 
+
+> **Note:** The name of your domain will be based on the email address provided during creation in the **&lt;_initials_&gt;&lt;_date_&gt;outlook.onmicrosoft.com** format. In the following exercises, you will need to edit **"*yourtenant*.onmicrosoft.com"** to match this domain name.
 
 6. Leave the Azure portal open for the next exercise.
 
@@ -81,23 +87,24 @@
 >  **Result**: After completing this exercise, you should have successfully created an Azure Active Directory (Azure AD) tenant.
 
 
+
 ## Exercise 2: Managing Azure AD users and groups
   
 #### Task 1: Create a standard user
   
-1. On  **LON-CL3**, on the Azure portal, in the navigation pane, select  **Azure Active Directory**, and then select  **Users and groups**.
+1. On  **LON-CL3**, on the Azure portal, in the navigation pane, select  **Azure Active Directory**, and then select  **Users**.
 
-2. Select  **Allusers**, and then select  **New user**.
+2. In the  **Users - All users** blade, select  **+ New user**.
 
-3. In the  **User** area, enter the following information:
+3. In the  **User** blade, enter the following information:
 
 
   - Name:  **Deanna Sheppard**
 
-  - Username:  **Deanna@yourtenant.onmicrosoft.com**
+  - Username:  **Deanna@*yourtenant*.onmicrosoft.com**
 
 
-3. Select  **Profile**, enter the following information, and then select  **OK**:
+4. Select  **Profile**, enter the following information, and then select  **OK**:
 
 
   - First name:  **Deanna**
@@ -107,41 +114,41 @@
   - Department:  **IT**
 
 
-4. Select the  **Show Password** check box, and note the password for later use.
+5. Select the  **Show Password** check box, and note the password for later use.
 
-5. Select  **Create**.
+6. Select  **Create**.
 
 
 
 #### Task 2: Create a global administrator
   
-1. On  **LON-CL3**, on the Azure portal, select  **New user**.
+1. On  **LON-CL3**, on the Azure portal, select  **+ New user**.
 
-2. In the  **User** area, enter the following information:
+2. In the  **User** blade, enter the following information:
 
 
   - Name:  **GAdmin**
 
-  - Username:  **GAdmin@yourtenant.onmicrosoft.com**
+  - Username:  **GAdmin@*yourtenant*.onmicrosoft.com**
 
 
-5. Select  **Directory role**, select  **Global administrator**, and then select  **OK**.
+3. Select  **Directory role**, select  **Global administrator**, and then select  **OK**.
 
-6. Select the  **Show Password** check box, and then note the password for later use.
+4. Select the  **Show Password** check box, and then note the password for later use.
 
-7. Select  **Create**.
+5. Select  **Create**.
 
-8. Close Microsoft Edge.
+6. Close Microsoft Edge.
 
 
 
-#### Task 3: Add a Microsoft Enterprise Mobility + Security trial subscription
+#### Task 3: Add a Microsoft Enterprise Mobility + Security E5 trial subscription
   
 1. On  **LON-CL3**, open Microsoft Edge.
 
-2. In Microsoft Edge, in the address bar, type  **https://portal.azure.com**, and then press Enter.
+2. In Microsoft Edge, in the address bar, type  [**https://portal.azure.com**](https://portal.azure.com), and then press Enter.
 
-3. Select  **Use another account**, and then sign in as  **GAdmin@yourtenant.onmicrosoft.com**.
+3. Select  **Use another account**, and then sign in as  **GAdmin@*yourtenant*.onmicrosoft.com**.
 
 4. When prompted, update the password for GAdmin, and then select  **Sign in**. Note the password that you use.
 
@@ -151,19 +158,19 @@
 
 7. Under  **Getting started with Azure AD**, select  **Get a free trial for Azure AD Premium**.
 
-8. In the  **ENTERPRISE MOBILITY SUITE** box, select **Free trial**.
+8. In the  **ENTERPRISE MOBILITY + SECURITY E5** box, select **Free trial**.
 
-9. In the  **Activate Enterprise Mobility Suite trial** area, select **Activate**.
+9. In the  **Activate Enterprise Mobility + Security E5 trial** blade, select **Activate**.
 
 
 
 #### Task 4: Create a group with static membership
   
-1. On  **LON-CL3**, on the Azure portal, in the navigation pane, select  **Azure Active Directory**, and then select  **Users and groups**.
+1. On  **LON-CL3**, on the Azure portal, in the navigation pane, select  **Azure Active Directory**, and then select  **Groups**.
 
-2. In the  **Users and groups** area, select **All groups**, and then select  **New group**.
+2. In the  **Groups - All groups** blade, select  **+ New group**.
 
-3. In the  **Group** area, enter the following information:
+3. In the  **Group** blade, enter the following information:
 
 
   - Name:  **StaticGroup**
@@ -171,23 +178,23 @@
   - Membership type:  **Assigned**
 
 
-3. Select  **Members**.
+4. Select  **Members**.
 
-4. In the  **Members** area, select **Deanna Sheppard** and **GAdmin**, and then select  **Select**.
+5. In the  **Members** area, select **Deanna Sheppard** and **GAdmin**, and then select  **Select**.
 
-5. In the  **Group** area, select **Create**.
+6. In the  **Group** area, select **Create**.
 
-6. Close the  **Group** area.
+7. Close the  **Group** blade.
 
 
 
 #### Task 5: Create a group with dynamic membership
   
-1. On  **LON-CL3**, on the Azure portal, in the navigation pane, select  **Azure Active Directory**, and then select  **Users and groups**.
+1. On  **LON-CL3**, on the Azure portal, in the navigation pane, select  **Azure Active Directory**, and then select  **Groups**.
 
-2. In the  **Users and groups** area, select **All groups**, and then select  **New group**.
+2. In the  **Groups - All groups** blade, select  **+ New group**.
 
-3. In the  **Group** area, enter the following information:
+3. In the  **Group** blade, enter the following information:
 
 
   - Name:  **DynamicGroup**
@@ -199,28 +206,31 @@
 
 5. In the  **Dynamic membership rules** area, create a simple rule to add users where **department Equals IT**, and then select  **Add query**.
 
-6. In the  **Group** area, select **Create**.
+6. In the  **Group** blade, select **Create**.
 
-7. Close the  **Group** area.
+7. Close the  **Group** blade.
 
-8. In the  **Users and groups - All groups** area, select **DynamicGroup**.
+8. In the  **Groups - All groups** blade, select **DynamicGroup**.
 
 9. In the  **DynamicGroup** area, select **Members**, and then verify that Deanna Sheppard is a member.
 
->  **Note:** If no DynamicGroup members are listed, wait a few minutes, and then refresh the membership list. It can take several minutes for the membership to populate.
+	>  **Note:** If no DynamicGroup members are listed, wait a few minutes, and then refresh the membership list. It can take several minutes for the membership to populate.
+
+<!-- -->
 
 >  **Result**: After this exercise, you will have successfully created cloud-based users and groups.
+
 
 
 ## Exercise 3: Configuring and enabling directory synchronization
   
 #### Task 1: Update UPNs to match Azure AD
   
-1. On  **LON-DC1**, select  **File Explorer**, and then browse to  **E:\Labfiles\Mod03**.
+1. On  **LON-DC1**, select  **File Explorer**, and then browse to  **E:\\Labfiles\\Mod03**.
 
 2. Right-click  **UpdateUPN.ps1**, and then select  **Edit**.
 
-3. On line three of the script, replace  **yourtenant** with the name of your Azure AD tenant.
+3. On line three of the script, replace  **_yourtenant_** with the name of your Azure AD tenant.
 
 4. Select  **Save**, and then press  **F5** to run the script.
 
@@ -228,7 +238,7 @@
 
 6. In  **Server Manager**, select  **Tools**, and then select  **Active Directory Administrative Center**.
 
-7. In Active Directory Administrative Center, in the navigation pane, select  **Adatum (local)**, and ** **then ** **double-click  **IT**.
+7. In Active Directory Administrative Center, in the navigation pane, select  **Adatum (local)**, and then double-click  **IT**.
 
 8. Select  **Abbi Skinner**, and then, in the Tasks pane, select  **Properties**.
 
@@ -240,7 +250,7 @@
 
 #### Task 2: Install Azure AD Connect
   
-1. On  **LON-DC1**, select  **File Explorer**, browse to  **E:\Labfiles**, and then double-click  **AzureADConnect.msi**.
+1. On  **LON-DC1**, select  **File Explorer**, browse to  **E:\\Labfiles**, and then double-click  **AzureADConnect.msi**.
 
 2. In the  **Open File - Security Warning** dialog box, select **Run**.
 
@@ -248,15 +258,16 @@
 
 4. On the  **Express Settings** page, read the information, and then select **Use express settings**.
 
-5. On the  **Connect to Azure AD** page, in the **USERNAME** text box, type **GAdmin@yourtenant.onmicrosoft.com**.
+5. On the  **Connect to Azure AD** page, in the **USERNAME** text box, type **GAdmin@*yourtenant*.onmicrosoft.com**.
 
 6. In the  **PASSWORD** text box, type the password, and then select **Next**.
 
-7. On the  **Connect to AD DS** page, in the **USERNAME** text box, type **Adatum\Administrator**.
+7. On the  **Connect to AD DS** page, in the **USERNAME** text box, type **Adatum\\Administrator**.
 
 8. In the  **PASSWORD** text box, type **Pa55w.rd**, and then select  **Next**.
 
 9. On the  **Azure AD sign-in configuration** page, select **Continue without any verified domains**, and then select  **Next**.
+
 >  **Note:** In a typical deployment, a domain name that is registered in Domain Name System (DNS) is used and there is no requirement to proceed without verified domains. This occurs because of limitations of the lab environment.
 
 10. On the  **Ready to configure** page, select **Start the synchronization process when configuration completes**, and then select  **Install**.
@@ -267,10 +278,12 @@
 
 #### Task 3: Verify that Azure AD Connect has populated Azure AD
   
-1. On  **LON-CL3**, on the Azure portal, in the navigation pane, select  **Azure Active Directory**, ** **and then select  **Azure AD Connect**.
+1. On  **LON-CL3**, on the Azure portal, in the navigation pane, select  **Azure Active Directory**, and then select  **Azure AD Connect**.
 
 2. Verify that the  **Sync Status** is **Enabled**.
+
 >  **Note:** If **Sync Status** is **Not Enabled**, then wait a few moments and refresh the page.
+
 3. In the  **Azure AD Connect** area, select **Users and groups**, and then on the  **Overview** page, verify that new users and groups have been added.
 
 4. Select  **All groups**, and then select  **DynamicGroup**.
@@ -294,7 +307,7 @@
 
 4. On the  **Set up a work or school account** page, select **Join this device to Azure Active Directory**.
 
-5. On the  **Let's get you signed in** page, type **Aidan@yourtenant.onmicrosoft.com**. For the password, type  **Pa55w.rd** and then select **Sign in**.
+5. On the  **Let's get you signed in** page, type **Aidan@*yourtenant*.onmicrosoft.com**. For the password, type  **Pa55w.rd** and then select **Sign in**.
 
 6. At the  **Make sure this is your organization** prompt, select **Join**.
 
@@ -304,17 +317,17 @@
 
 9. In Microsoft Edge, in the address, bar, type  **portal.azure.com**, and then press Enter.
 
-10. On the  **Microsoft Azure** page, sign in as **GAdmin@yourtenant.onmicrosoft.com**.
+10. On the  **Microsoft Azure** page, sign in as **GAdmin@*yourtenant*.onmicrosoft.com**.
 
 11. On the Azure portal, in the navigation pane, select  **Azure Active Directory**, and then select  **Devices**.
 
-12. Select  **LON-CL3**, ** **and then verify that the owner of  **LON-CL3** is Aidan Norman.
+12. Select  **LON-CL3**, and then verify that the owner of  **LON-CL3** is Aidan Norman.
 
 13. Close Microsoft Edge.
 
 14. Restart  **LON-CL3**.
 
-15. On the sign-in screen, select  **Other user**, and then sign in as  **Aidan@yourtenant.onmicrosoft.com** with the password **Pa55w.rd**.
+15. On the sign-in screen, select  **Other user**, and then sign in as  **Aidan@*yourtenant*.onmicrosoft.com** with the password **Pa55w.rd**.
 
 16. Ensure that you can sign in. This demonstrates that your computer now trusts Azure AD.
 
@@ -326,7 +339,7 @@
 
 #### Task 2: Verify that the computer has the Azure AD certificates
   
-1. On  **LON-CL3**, select  **Start**, type  **mmc.exe**, ** **and then press  **Enter**.
+1. On  **LON-CL3**, select  **Start**, type  **mmc.exe**, and then press  **Enter**.
 
 2. In the  **User Account Control** window, select **Yes**.
 
@@ -338,7 +351,7 @@
 
 6. On the  **Select Computer** page, select **Finish**, and then select  **OK**.
 
-7. In the  **Console1** window, expand **Certificates**, expand  **Personal**, ** **and then select the  **Certificates** folder.
+7. In the  **Console1** window, expand **Certificates**, expand  **Personal**, and then select the  **Certificates** folder.
 
 8. Ensure that you see certificates that were issued by  **MS-Organization-Access** and **MS-Organization-P2P-Access**.
 

--- a/Instructions/206972C_LAB_AK_04.md
+++ b/Instructions/206972C_LAB_AK_04.md
@@ -1,4 +1,4 @@
-# Lab Answer Key:  Module 4: Managing user profiles and UE-V
+﻿# Lab Answer Key:  Module 4: Managing user profiles and UE-V
 # Lab A: Configuring user profiles and UE-V
   
 ## Exercise 1: Configuring roaming user profiles, Folder Redirection, and the primary computer setting
@@ -7,17 +7,17 @@
   
 1. On  **LON-DC1**, on the taskbar, select  **File Explorer**. In the navigation pane, select  **Local Disk (C:)**.
 
-2. In File Explorer, ** **in the details pane, right-click an empty space, point to  **New**, and then select  **Folder**. Type  **Profiles** as the folder name, and then press Enter.
+2. In File Explorer, in the details pane, right-click an empty space, point to  **New**, and then select  **Folder**. Type:  **Profiles** as the folder name, and then press Enter.
 
-3. Right-click the  **Profiles** folder, select **Share with**, ** **and then select  **Specific people**.
+3. Right-click the  **Profiles** folder, select **Share with**, and then select  **Specific people**.
 
-4. In the  **File Sharing** dialog box, in the text box, type **domain users**, select  **Add**, select the arrow near  **Read** for **Domain Users**, select  **Read/Write**, select  **Share** and then select **Done**.
+4. In the  **File Sharing** dialog box, in the text box, type: **domain users**, select  **Add**, select the arrow near  **Read** for **Domain Users**, select  **Read/Write**, select  **Share** and then select **Done**.
 
-5. In  **File Explorer**, in the details pane, right-click an empty space, point to  **New**, and then select  **Folder**. Type  **Redirected** as the folder name, and then press Enter.
+5. In  **File Explorer**, in the details pane, right-click an empty space, point to  **New**, and then select  **Folder**. Type:  **Redirected** as the folder name, and then press Enter.
 
 6. Right-click the  **Redirected** folder, select **Share with** and then select **Specific people**.
 
-7. In the  **File Sharing** dialog box, in the text box, type **domain users**, select  **Add**, select the arrow near  **Read** for **Domain Users**, select  **Read/Write**, select  **Share**, ** **select  **Done**, and then close File Explorer.
+7. In the  **File Sharing** dialog box, in the text box, type: **domain users**, select  **Add**, select the arrow near  **Read** for **Domain Users**, select  **Read/Write**, select  **Share**, select  **Done**, and then close File Explorer.
 
 
 
@@ -31,7 +31,8 @@
 
 4. In the details pane, right-click  **Ada Russell**, and then select  **Properties**.
 
-5. In the  **Ada Russell Properties** dialog box, on the **Profile** tab, in the **Profile path** text box, type **\\LON-DC1\Profiles\%username%**, and then select  **OK**.
+5. In the  **Ada Russell Properties** dialog box, on the **Profile** tab, in the **Profile path** text box, type:  
+**\\\\LON-DC1\\Profiles\\%username%**, and then select  **OK**.
 
 6. Minimize the  **Active Directory Users and Computers** window.
 
@@ -41,21 +42,26 @@
   
 1. On  **LON-DC1**, in  **Server Manager**, select  **Tools**, and then select  **Group Policy Management**.
 
-2. In the  **Group Policy Management** console (GPMC), in the navigation pane, expand **Forest: Adatum.com**, expand  **Domains**, ** **and then expand  **Adatum.com**.
+2. In the  **Group Policy Management** console (GPMC), in the navigation pane, expand  
+**Forest: Adatum.com**, expand  **Domains**, and then expand  **Adatum.com**.
 
-3. In the navigation pane, right-click the  **Marketing** OU, and then select **Create a GPO in this domain, and Link it here**. 
+3. In the navigation pane, right-click the  **Marketing** OU, and then select  
+**Create a GPO in this domain, and Link it here**. 
 
-4. In the  **Name** text box, type **Folder Redirection**, and then select  **OK**.
+4. In the  **Name** text box, type: **Folder Redirection**, and then select  **OK**.
 
-5. In the GPMC, in the navigation pane, expand the  **Marketing** OU, right-click **Folder Redirection**, and then select  **Edit**. The  **Group Policy Management Editor** window opens.
+5. In the GPMC, in the navigation pane, expand the  **Marketing** OU, right-click **Folder Redirection**,  
+and then select  **Edit**. The  **Group Policy Management Editor** window opens.
 
 6. In the  **Group Policy Management Editor** window, under **User Configuration** in the navigation pane, expand **Policies**, expand  **Windows Settings**, and then expand  **Folder Redirection**.
 
-7. Right-click  **Documents**, ** **and then select  **Properties**.
+7. Right-click  **Documents**, and then select  **Properties**.
 
-8. In the  **Documents Properties** dialog box, in the **Setting** drop-down box, select **Basic – Redirect everyone’s folder to the same location**. 
+8. In the  **Documents Properties** dialog box, in the **Setting** drop-down box, select:  
+**Basic – Redirect everyone’s folder to the same location**. 
 
-9. In the  **Target folder location** section, in the **Root Path** text box, type **\\LON-DC1\Redirected**, ** **and then select  **OK**.
+9. In the  **Target folder location** section, in the **Root Path** text box, type: **\\\\LON-DC1\\Redirected**,  
+and then select  **OK**.
 
 10. In the  **Warning** dialog box, select **Yes**. 
 
@@ -65,64 +71,73 @@
 
 #### Task 4: Test roaming user profiles and Folder Redirection
   
-1. On  **LON-DC1**, on the taskbar, select  **File Explorer**. ** **
+1. On  **LON-DC1**, on the taskbar, select  **File Explorer**.
 
-2. In  **File Explorer**, in the navigation pane, select  **Local Disk (C:)**, ** **and then verify that the  **Profiles** and **Redirected** folders are empty.
+2. In  **File Explorer**, in the navigation pane, select  **Local Disk (C:)**, and then verify that the  **Profiles** and **Redirected** folders are empty.
 
-3. Sign in to  **LON-CL1** as **Adatum\Ada** with the password **Pa55w.rd**.
+3. Sign in to  **LON-CL1** as **Adatum\\Ada** with the password **Pa55w.rd**.
 
-4. Right-click anywhere on the desktop, point to  **New**, ** **and then select  **Folder**. Type  **Presentations** as the folder name, and then press Enter.
+4. Right-click anywhere on the desktop, point to  **New**, and then select  **Folder**. Type:  **Presentations** as the folder name, and then press Enter.
 
 5. On the desktop, right-click anywhere, point to  **New**, and then select  **Shortcut**. 
 
-6. Click  **Browse**, ** **expand  **This PC**, select  **Local Disk (C:)**, select  **OK**, select  **Next**, and then select  **Finish**. A shortcut to local disk C ** **is added to the desktop.
+6. Click  **Browse**, expand  **This PC**, select  **Local Disk (C:)**, select  **OK**, select  **Next**, and then select  **Finish**.  
+A shortcut to local disk C: is added to the desktop.
 
-7. On the taskbar, select  **Start**, type  **notepad**, and then press Enter. 
+7. On the taskbar, select  **Start**, type:  **notepad**, and then press Enter. 
 
-8. In  **Notepad**, type your name. On the  **File** menu, select **Save As**, select the  **Documents** folder in the navigation pane, enter your name in the **File Name** text box, select **Save**, and then close  **Notepad**.
+8. In  **Notepad**, type:  **_&lt;your name&gt;_**. On the  **File** menu, select **Save As**, select the  **Documents** folder in the navigation pane, type:  **_&lt;your name&gt;_** in the **File Name** text box, select **Save**, and then close  **Notepad**.
 
-9. On the taskbar, select  **File Explorer**, and then in the navigation pane, select  **Documents**. In the details pane, right-click the file with your name, and then select  **Properties**. Verify that the location of that file points to the network, to  **\\LON-DC1\Redirected\Ada\Documents**, and that it is not stored inside Ada Russell’s local profile. Also, verify that there is an  **Offline Files** tab in the **File Properties** dialog box, and then select **OK**.
+9. On the taskbar, select  **File Explorer**, and then in the navigation pane, select  **Documents**. In the details pane, right-click the file with **_&lt;your name&gt;_**, and then select  **Properties**. Verify that the location of that file points to the network, to  **\\\\LON-DC1\\Redirected\\Ada\\Documents**, and that it is not stored inside Ada Russell’s local profile. Also, verify that there is an  **Offline Files** tab in the **File Properties** dialog box, and then select **OK**.
 
-10. In the  **20697-2C-LON-CL1** window, select **File**, ** **and then select  **Settings**.
+10. In the  **20697-2C-LON-CL1** window, select **File**, and then select  **Settings**.
 
 11. In the  **Settings for 20697-2C-LON-CL1** window, in the navigation pane, select **Network Adapter**. In the details pane, in the  **Virtual switch** dropdown list, select **Not connected**, and then select  **OK**.
 
-12. In  **File Explorer**, in the details pane, right-click an empty space, select  **New**, select  **Text document**, type  **File1** as the file name, and then press Enter.
+12. In  **File Explorer**, in the details pane, right-click an empty space, select  **New**, select  **Text document**, type:  **File1** as the file name, and then press Enter.
 
 13. Right-click  **File1**, and then select  **Properties**. In the  **File1 Properties** dialog box, on the **Offline Files** tab verify that **File1** is offline with unsynced changes, and then select **OK**.
 
-14. Double-click the file with your name. The file opens in Notepad, even when you do not have network connectivity. Type today’s date, close  **Notepad**, and select  **Save**.
+14. Double-click the file with  **_&lt;your name&gt;_**. The file opens in Notepad, even when you do not have network connectivity. Type today’s date, close  **Notepad**, and select  **Save**.
 
-15. In the  **20697-2C-LON-CL1** window, select **File**, ** **and then select  **Settings**.
+15. In the  **20697-2C-LON-CL1** window, select **File**, and then select  **Settings**.
 
-16. In the  **Settings for 20697-2C-LON-CL1** window, in the navigation pane, select **Network Adapter**. In the details pane, in the  **Virtual switch** dropdown list, select **Private Network**, and then select  **OK**.
+16. In the  **Settings for 20697-2C-LON-CL1** window, in the navigation pane, select **Network Adapter**.  
+In the details pane, in the  **Virtual switch** dropdown list, select **Private Network**, and then select  **OK**.
+
 >  **Note:** Wait a few seconds till the **File Explorer** status bar shows an **Online** status.
-17. Right-click  **File1**, and then select  **Properties**. In the  **File1 Properties** dialog box, ** **on the  **Offline Files** tab, verify that **File1** is now online, and then select **OK**.
+
+17. Right-click  **File1**, and then select  **Properties**. In the  **File1 Properties** dialog box, on the  **Offline Files** tab, verify that **File1** is now online, and then select **OK**.
 
 18. On the taskbar, right-click  **Start**, select  **Shut down or sign out**, ** **and then select  **Sign out**.
 
-19. On  **LON-DC1**, in  **File Explorer**, verify that the  **C:\Profiles** and **C:\Redirected** folders are no longer empty. The **Profiles** folder contains the Ada Russell roaming user profile ( **Ada.V6**), while the  **Redirected** folder contains Ada Russell’s ** **redirected  **Documents** folder.
+19. On  **LON-DC1**, in  **File Explorer**, verify that the  **C:\\Profiles** and **C:\\Redirected** folders are no longer empty. The **Profiles** folder contains the Ada Russell roaming user profile (**Ada.V6**), while the  **Redirected** folder contains Ada Russell’s redirected  **Documents** folder.
 
-20. Sign in to  **LON-CL2** as **Adatum\Ada** with the password **Pa55w.rd**.
+20. Sign in to  **LON-CL2** as **Adatum\\Ada** with the password **Pa55w.rd**.
 
-21. Verify that the  **Presentations** folder and the **Local Disk (C)** shortcut are on the desktop.
+21. Verify that the  **Presentations** folder and the **Local Disk (C:)** shortcut are on the desktop.
 
-22. On the taskbar, select  **Start**, type  **notepad**, and then press Enter.
+22. On the taskbar, select  **Start**, type:  **notepad**, and then press Enter.
 
-23. In  **Notepad**, on the  **File** menu, select ** Open**, verify that you can see both the files that you created on  **LON-CL1**, select the file with your name, and then select  **Open**. 
->  **Note:** The file includes your name and the date. You added the date and saved the file on **LON-CL1** when you did not have network connectivity.
-24. On the taskbar, right-click  **Start**, select  **Shut down or sign out**, ** **and then select  **Sign out**.
+23. In  **Notepad**, on the  **File** menu, select **Open**, verify that you can see both the files that you created on  **LON-CL1**, select the file with  **_&lt;your name&gt;_**, and then select  **Open**.
+ 
+>  **Note:** The file includes  **_&lt;your name&gt;_** and the date. You added the date and saved the file on **LON-CL1** when you did not have network connectivity.
+
+24. On the taskbar, right-click  **Start**, select  **Shut down or sign out**, and then select  **Sign out**.
 
 
 
 #### Task 5: Configure the primary computer setting
   
-1. On  **LON-DC1**, maximize the  **Active Directory Users and Computers** window. ** **To turn on  **Advanced Features** view, on the **View** menu, select **Advanced Features**.
+1. On  **LON-DC1**, maximize the  **Active Directory Users and Computers** window. To turn on  **Advanced Features** view, on the **View** menu, select **Advanced Features**.
 
 2. In the  **Active Directory Users and Computers** navigation pane, select the **Computers** container, in the details pane, right-click the **LON-CL1** computer account, and then select **Properties**.
 
 3. On the  **Attribute Editor** tab, in the **Attributes** section, double-click the **distinguishedName** attribute, press Ctrl+C to copy its value to the Clipboard, and then select **OK** twice.
->  **Note:** The **distinguishedName** attribute should appear similar to the following: **CN=LON-CL1,CN=Computers,DC=adatum,DC=com**.
+
+>  **Note:** The **distinguishedName** attribute should appear similar to the following:   
+   **CN=LON-CL1,CN=Computers,DC=adatum,DC=com**.
+
 4. In the navigation pane, select the  **Marketing** OU, and in the details pane, right-click **Ada Russell**, and then select  **Properties**.
 
 5. On the  **Attribute Editor** tab, in the **Attributes** section, select the **msDS-PrimaryComputer** attribute, and then select **Edit**.
@@ -139,35 +154,39 @@
 
 11. Maximize the GPMC, right-click the  **Default Domain Policy** Group Policy, and then select **Edit**.
 
-12. In the  **Group Policy Management Editor** window, navigate to **Computer Configuration\Policies\Administrative Templates\System\User Profiles**. Double-click the  **Download roaming profiles on primary computers only** policy setting, select **Enabled**, ** **and then select  **OK**.
+12. In the  **Group Policy Management Editor** window, navigate to:  
+**Computer Configuration\\Policies\\Administrative Templates\\System\\User Profiles**.  
+Double-click the  **Download roaming profiles on primary computers only** policy setting, select **Enabled**, and then select  **OK**.
 
-13. In the  **Group Policy Management Editor** window, navigate to **User Configuration\Policies\Administrative Templates\System\Folder Redirection**. Double-click the  **Redirect folders on primary computers only** policy setting, select **Enabled**, ** **and then select  **OK**.
+13. In the  **Group Policy Management Editor** window, navigate to:  
+**User Configuration\\Policies\\Administrative Templates\\System\\Folder Redirection**.  
+Double-click the  **Redirect folders on primary computers only** policy setting, select **Enabled**, and then select  **OK**.
 
 14. Close the  **Group Policy Management Editor** window and the GPMC.
 
 15. On  **LON-CL4**, on the taskbar, select  **File Explorer**, right-click  **This PC**, and then select  **Properties**.
 
-16. In the  **System** window, ** **select  **Change settings**.
+16. In the  **System** window, select  **Change settings**.
 
-17. In  **System Properties**, select  **Change**. Select the  **Domain** option, type **Adatum.com** in the **Domain** text box, and then select **OK**.
+17. In  **System Properties**, select  **Change**. Select the  **Domain** option, type: **Adatum.com** in the **Domain** text box, and then select **OK**.
 
-18. In the  **User name** text box, type **Administrator**, in the  **Password** text box, type **Pa55w.rd**, select  **OK** four times, select **Close**, and then select  **Restart Now**.
+18. In the  **User name** text box, type: **Administrator**, in the  **Password** text box, type: **Pa55w.rd**, select  **OK** four times, select **Close**, and then select  **Restart Now**.
 
 
 
 #### Task 6: Test the primary computer setting
   
-1. Sign in to  **LON-CL4** as **Adatum\Ada** with the password **Pa55w.rd**.
+1. Sign in to  **LON-CL4** as **Adatum\\Ada** with the password **Pa55w.rd**.
 
-2. Verify that the  **Presentations** folder and the **Local Disk (C)** shortcut are not on the desktop. This is because **LON-CL4** is not set as one of Ada Russell’s primary computers, and her roaming user profile is not available on **LON-CL4**.
+2. Verify that the  **Presentations** folder and the **Local Disk (C:)** shortcut are not on the desktop. This is because **LON-CL4** is not set as one of Ada Russell’s primary computers, and her roaming user profile is not available on **LON-CL4**.
 
-3. On the taskbar, select  **Start**, type  **notepad**, and then press Enter. 
+3. On the taskbar, select  **Start**, type:  **notepad**, and then press Enter. 
 
-4. In  **Notepad**, on the  **File** menu, select ** Open**, and then in the navigation pane, select  **Documents**. ** **Verify that the folder is empty and the file with your name is not available. This is because  **LON-CL4** is not set as one of Ada Russell’s primary computers, and her redirected folders are not available on **LON-CL4**. Select  **Cancel**.
+4. In  **Notepad**, on the  **File** menu, select **Open**, and then in the navigation pane, select  **Documents**. Verify that the folder is empty and the file with  **_&lt;your name&gt;_** is not available. This is because  **LON-CL4** is not set as one of Ada Russell’s primary computers, and her redirected folders are not available on **LON-CL4**. Select  **Cancel**.
 
-5. On the taskbar, right-click  **Start**, select  **Shut down or sign out**, ** **and then select  **Sign out**.
+5. On the taskbar, right-click  **Start**, select  **Shut down or sign out**, and then select  **Sign out**.
 
-6. On  **LON-DC1**, maximize the  **Active Directory Users and Computers** window, ** select** the **Marketing** OU in the navigation pane, right-click **Ada Russell** in the details pane, and then select **Properties**.
+6. On  **LON-DC1**, maximize the  **Active Directory Users and Computers** window, select the **Marketing** OU in the navigation pane, right-click **Ada Russell** in the details pane, and then select **Properties**.
 
 7. On the  **Attribute Editor** tab, in the Attributes section, select the **msDS-PrimaryComputer** attribute, and then select **Edit**.
 
@@ -177,20 +196,23 @@
 
 10. Sign in to  **LON-CL4** as **Ada Russell** with the password **Pa55w.rd**.
 
-11. Verify that the  **Presentations** folder and the **Local Disk (C)** shortcut are on the desktop. This is because you configured **LON-CL4** as Ada Russell’s primary computer and her roaming user profile is effective.
+11. Verify that the  **Presentations** folder and the **Local Disk (C:)** shortcut are on the desktop. This is because you configured **LON-CL4** as Ada Russell’s primary computer and her roaming user profile is effective.
 
 12. On the taskbar, select the  **File Explorer** icon.
 
 13. In  **File Explorer**, in the navigation pane, select  **Document**s.
->  **Note:** The details pane is empty because the **Folder Redirection** GPO did not apply at first sign in. Sign out and sign in as **Ada Russell** with the password **Pa55w.rd**, ** **and then repeat steps 12 and 13.
-14. In  **File Explorer**, in the details pane, double-click the file with your name. The file opens in  **Notepad**. Because you configured  **LON-CL4** as Ada Russell’s primary computer, redirected folders are available.
 
-15. In  **Notepad**, on the  **File** menu, select ** Exit**.
+>  **Note:** The details pane is empty because the **Folder Redirection** GPO did not apply at first sign in. Sign out and sign in as **Ada Russell** with the password **Pa55w.rd**, and then repeat steps 12 and 13.
+
+14. In  **File Explorer**, in the details pane, double-click the file with  **_&lt;your name&gt;_**. The file opens in  **Notepad**. Because you configured  **LON-CL4** as Ada Russell’s primary computer, redirected folders are available.
+
+15. In  **Notepad**, on the  **File** menu, select **Exit**.
 
 16. In the  **20697-2C-LON-CL4** window, select **Action**, select  **Revert** twice, and then close the **20697-2C-LON-CL4** window.
 
 
 >  **Result**: After completing this exercise, you should have configured roaming user profiles and Folder Redirection. You also should have configured a user with the primary computer setting.
+
 
 
 ## Exercise 2: Implementing and using UE-V
@@ -201,17 +223,17 @@
 
 2. In File Explorer, in the navigation pane, select  **Local Disk (C:)**.
 
-3. In File Explorer, ** **in the details pane, right-click an empty space, point to  **New**, and then select  **Folder**. Type  **UEVData** as the folder name, and then press Enter.
+3. In File Explorer, in the details pane, right-click an empty space, point to  **New**, and then select  **Folder**. Type:  **UEVData** as the folder name, and then press Enter.
 
-4. In  **File Explorer**, right-click  **UEVData**, select  **Share with**, ** **and then select  **Specific people**.
+4. In  **File Explorer**, right-click  **UEVData**, select  **Share with**, and then select  **Specific people**.
 
-5. In the  **File Sharing** dialog box, in the text box, type **domain users**, select  **Add**, select the arrow near  **Read** for ** Domain Users**, select  **Read/Write**, select  **Share**, ** **and then select  **Done**.
+5. In the  **File Sharing** dialog box, in the text box, type: **domain users**, select  **Add**, select the arrow near  **Read** for **Domain Users**, select  **Read/Write**, select  **Share**, and then select  **Done**.
 
-6. In  **File Explorer**, in the details pane, right-click an empty space, point to  **New**, and then select ** Folder**. Type  **UEVTemplates** as the folder name, and then press Enter.
+6. In  **File Explorer**, in the details pane, right-click an empty space, point to  **New**, and then select **Folder**. Type:  **UEVTemplates** as the folder name, and then press Enter.
 
-7. In  **File Explorer**, right-click the  **UEVTemplates**, select  **Share with**, ** **and then select  **Specific people**.
+7. In  **File Explorer**, right-click the  **UEVTemplates**, select  **Share with**, and then select  **Specific people**.
 
-8. In the  **File Sharing** dialog box, in the text box type **domain users**, select  **Add**, select the arrow near  **Read** for ** Domain Users**, select  **Read/Write**, select  **Share**, ** **and then select  **Done**.
+8. In the  **File Sharing** dialog box, in the text box type: **domain users**, select  **Add**, select the arrow near  **Read** for **Domain Users**, select  **Read/Write**, select  **Share**, and then select  **Done**.
 
 9. Minimize File Explorer.
 
@@ -221,9 +243,9 @@
   
 1. On  **LON-DC1**, in  **Server Manager**, select  **Tools**, and then select  **Group Policy Management**.
 
-2. In the GPMC, in the navigation pane, expand  **Forest: Adatum.com**, expand  **Domains**, ** **and then expand  **Adatum.com**.
+2. In the GPMC, in the navigation pane, expand  **Forest: Adatum.com**, expand  **Domains**, and then expand  **Adatum.com**.
 
-3. In the navigation pane, right-click the  **Adatum.com**, and then select  **Create a GPO in this domain, and Link it here**. In the  **Name** text box type **UE-V**, and then select  **OK**.
+3. In the navigation pane, right-click the  **Adatum.com**, and then select  **Create a GPO in this domain, and Link it here**. In the  **Name** text box type: **UE-V**, and then select  **OK**.
 
 4. In the GPMC, in the navigation pane, right-click the  **UE-V** Group Policy, and then select **Edit**.
 
@@ -231,75 +253,84 @@
 
 6. In the details pane, right-click  **Enable UEV**, select  **Edit**, select  **Enabled**, and then select  **OK**.
 
-7. In the details pane, right-click  **Settings template catalog path**, select  **Edit**, select  **Enabled**, in the  **Settings template catalog path** text box, type **\\LON-DC1\UEVTemplates**, and then select  **OK**.
+7. In the details pane, right-click  **Settings template catalog path**, select  **Edit**, select  **Enabled**, in the  **Settings template catalog path** text box, type:  **\\\\LON-DC1\\UEVTemplates**, and then select  **OK**.
 
 8. In the  **Group Policy Management Editor** window, in the navigation pane, under **User Configuration**, expand  **Policies**, expand  **Administrative Templates**, expand  **Windows Components**, and then select the  **Microsoft User Experience Virtualization** node.
 
-9. In the details pane, right-click  **Settings storage path**, select  **Edit**, select  **Enabled**, in the  **Settings storage path** text box, type **\\LON-DC1\UEVData\%username%**, and then select  **OK**.
+9. In the details pane, right-click  **Settings storage path**, select  **Edit**, select  **Enabled**, in the  **Settings storage path** text box, type: **\\\\LON-DC1\\UEVData\\%username%**, and then select  **OK**.
 
-10. In the details pane, right-click  **Synchronize Windows settings**, select  **Edit**, select  **Enabled**, select the  **Roaming Credentials** check box, and then select **OK**. 
+10. In the details pane, right-click  **Synchronize Windows settings**, select  **Edit**, select  **Enabled**, select the  **Roaming Credentials** check box, and then select **OK**.
+ 
 >  **Note:** All five check boxes are selected.
+
 11. Close the  **Group Policy Management Editor** window and the GPMC.
 
 
 
 #### Task 3: Enable UE-V, and then verify the effective settings
   
-1. Sign in to  **LON-CL1** as **Adatum\Administrator** with the password **Pa55w.rd**.
+1. Sign in to  **LON-CL1** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
-2. On the taskbar, select  **Start**, type  **PowerShell**, and then press Enter.
+2. On the taskbar, select  **Start**, type:  **PowerShell**, and then press Enter.
 
-3. In Windows PowerShell, type  **Get-UevStatus**, and then press Enter. The output shows that UE-V is currently not enabled.
+3. In Windows PowerShell, type:  **Get-UevStatus**, and then press Enter. The output shows that UE-V is currently not enabled.
 
-4. In Windows PowerShell, type  **Enable-Uev** to enable UE-V, and then press Enter.
+4. In Windows PowerShell, type:  **Enable-Uev** to enable UE-V, and then press Enter.
+
 >  **Note:** You must restart the computer for this change to take effect.
-5. In Windows PowerShell, type  **Get-UevTemplate**, and then press Enter. There is no output, because by default, no settings location template is registered.
 
-6. In  **Windows PowerShell**, type  **Register-UevTemplate -Path C:\ProgramData\Microsoft\UEV\InboxTemplates\*.xml**, and then press Enter to register the default UE-V templates.
+5. In Windows PowerShell, type:  **Get-UevTemplate**, and then press Enter. There is no output, because by default, no settings location template is registered.
 
-7. In  **Windows PowerShell**, type  **Get-UevTemplate**, and then press Enter. The output shows the default UE-V templates, which are now registered.
+6. In  **Windows PowerShell**, type:  
+**Register-UevTemplate -Path C:\\ProgramData\\Microsoft\\UEV\\InboxTemplates\\\*.xml**, and then press Enter to register the default UE-V templates.
 
-8. In  **Windows PowerShell**, type  **Restart-Computer**, ** **and then press Enter.
+7. In  **Windows PowerShell**, type:  **Get-UevTemplate**, and then press Enter. The output shows the default UE-V templates, which are now registered.
 
-9. Sign in to  **LON-CL2** as **Adatum\Administrator** with the password **Pa55w.rd**.
+8. In  **Windows PowerShell**, type:  **Restart-Computer**, and then press Enter.
 
-10. On the taskbar, select  **Start**, type  **PowerShell**, and then press Enter.
+9. Sign in to  **LON-CL2** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
-11. In  **Windows PowerShell**, type  **C:\Labfiles\Mod04\ConfigureUEV.ps1**, ** **and then press Enter. This script performs the same configuration as you manually did on  **LON-CL1**.
+10. On the taskbar, select  **Start**, type:  **PowerShell**, and then press Enter.
+
+11. In  **Windows PowerShell**, type:  **C:\\Labfiles\\Mod04\\ConfigureUEV.ps1**, and then press Enter. This script performs the same configuration as you manually did on  **LON-CL1**.
 
 
 
 #### Task 4: Configure UE-V SyncMethod
   
-1. Sign in to  **LON-CL1** and ** LON-CL2** as **Adatum\Administrator** with the password **Pa55w.rd**.
+1. Sign in to  **LON-CL1** and **LON-CL2** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
-2. On  **LON-CL1**, on the taskbar, select  **Start**, type  **PowerShell**, and then press Enter.
+2. On  **LON-CL1**, on the taskbar, select  **Start**, type:  **PowerShell**, and then press Enter.
 
-3. In  **Windows PowerShell**, type  **Get-UevConfiguration** to view the current UE-V configuration, and then press Enter. You will see that values for **SettingsStoragePath** and **SettingsTemplateCatalogPath** are configured as you set them in Group Policy.
+3. In  **Windows PowerShell**, type:  **Get-UevConfiguration** to view the current UE-V configuration, and then press Enter. You will see that values for **SettingsStoragePath** and **SettingsTemplateCatalogPath** are configured as you set them in Group Policy.
+
 >  **Note:** Notice that **SyncMethod** is set to **SyncProvider**. This means that UE-V is using the local setting cache, which is synced with the shared network folder every 30 minutes.
+
 4. View all UE-V Windows PowerShell cmdlets by running the  **Get-Command –Module UEV** cmdlet.
 
-5. In  **Windows PowerShell**, type  **notepad**, ** **and then press Enter.
+5. In  **Windows PowerShell**, type:  **notepad**, and then press Enter.
 
-6. In  **Notepad**, in the  **Format** menu, select **Font**. In the  **Font** window, select **Verdana** font, and in the **Size** box, select **48**, select  **OK**, type your name to verify that the selected font is used, close  **Notepad**, and then select  **Don’t Save**.
+6. In  **Notepad**, in the  **Format** menu, select **Font**. In the  **Font** window, select **Verdana** font, and in the **Size** box, select **48**, select  **OK**, type:  **_&lt;your name&gt;_** to verify that the selected font is used, close  **Notepad**, and then select  **Don’t Save**.
 
-7. On  **LON-CL2**, on the taskbar, select  **Start**, type  **PowerShell**, and then press Enter.
+7. On  **LON-CL2**, on the taskbar, select  **Start**, type:  **PowerShell**, and then press Enter.
 
-8. In  **Windows PowerShell**, type  **notepad**, and then press Enter.
+8. In  **Windows PowerShell**, type:  **notepad**, and then press Enter.
 
-9. In  **Notepad**, type your name. You will notice that the default font is used and not the font that you selected on  **LON-CL1**. Close Notepad, and do not save changes.
+9. In  **Notepad**, type:  **_&lt;your name&gt;_**. You will notice that the default font is used and not the font that you selected on  **LON-CL1**. Close Notepad, and do not save changes.
+
 >  **Note:** UE-V uses the local settings cache by default. This is the reason why changes from **LON-CL1** are not used on **LON-CL2** yet.
-10. In Windows PowerShell, type  **Set-UevConfiguration–SyncMethod None** to configure UE-V to read settings directly from the network instead from the local settings cache, and then press Enter.
 
-11. In Windows PowerShell, type  **notepad**, and then press Enter.
+10. In Windows PowerShell, type:  **Set-UevConfiguration–SyncMethod None** to configure UE-V to read settings directly from the network instead from the local settings cache, and then press Enter.
 
-12. In Notepad, type your name. You will notice that the large Verdana font that you selected on  **LON-CL1** is being used. UE-V on **LON-CL2** is now reading settings from the network location.
+11. In Windows PowerShell, type:  **notepad**, and then press Enter.
 
-13. In Notepad, select  **Format**, select  **Font**, select  **Arial** font, select Size **26**, select  **OK**, ** **and then close Notepad without saving changes.
+12. In Notepad, type:  **_&lt;your name&gt;_**. You will notice that the large Verdana font that you selected on  **LON-CL1** is being used. UE-V on **LON-CL2** is now reading settings from the network location.
 
-14. On  **LON-CL1**, in Windows PowerShell, type  **Set-UevConfiguration–SyncMethodNone**, ** **and then press Enter.
+13. In Notepad, select  **Format**, select  **Font**, select  **Arial** font, select Size **26**, select  **OK**, and then close Notepad without saving changes.
 
-15. In Windows PowerShell, type  **notepad**, ** **and then press Enter.
+14. On  **LON-CL1**, in Windows PowerShell, type:  **Set-UevConfiguration–SyncMethodNone**, and then press Enter.
+
+15. In Windows PowerShell, type:  **notepad**, and then press Enter.
 
 16. In Notepad, verify that  **Arial** font size **26** is used, as you selected on **LON-CL2**. This is because you configured UE-V on  **LON-CL1** to read the settings directly from the network.
 
@@ -310,69 +341,77 @@
 
 #### Task 5: Use UE-V synchronization
   
-1. On  **LON-CL2**, on the taskbar, select  **Start**, ** **type  **wordpad**, and then press Enter.
+1. On  **LON-CL2**, on the taskbar, select  **Start**, type:  **wordpad**, and then press Enter.
 
 2. In WordPad, select the  **View** tab, and then verify that the **Ruler** and **Status bar** check boxes are selected by default. Clear the **Ruler** and **Status bar** check boxes, and then close **WordPad**.
 
 3. On the desktop, right-click anywhere, point to  **New**, and then select  **Shortcut**. Select  **Browse**, ** **expand  **This PC**, select  **Local Disk (C:)**, select  **OK**, select  **Next**, and then select  **Finish**. 
->  **Note:** A shortcut to **Local Disk (C)** is added to the desktop.
-4. On the taskbar, select  **Start**, ** **type  **notepad**, and then press Enter. Type your name in Notepad. On the  **File** menu, select **Save As**, in the navigation pane select  **Documents**, type your name in the  **File Name** text box, select **Save** and then close Notepad.
 
-5. On the taskbar, select  **Start**, ** **type  **certmgr.msc**, and then press Enter.
+>  **Note:** A shortcut to **Local Disk (C:)** is added to the desktop.
+
+4. On the taskbar, select  **Start**, type:  **notepad**, and then press Enter. Type:  **_&lt;your name&gt;_** in Notepad. On the  **File** menu, select **Save As**, in the navigation pane select  **Documents**, type:  **_&lt;your name&gt;_** in the  **File Name** text box, select **Save** and then close Notepad.
+
+5. On the taskbar, select  **Start**, type:  **certmgr.msc**, and then press Enter.
 
 6. In the  **Certificates** console, in the navigation pane, right-click **Personal**, select  **All Tasks**, ** **and then select  **Request New Certificate**. 
 
-7. In the  **Certificate Enrollment** wizard, select **Next** twice, select the **User** checkbox, select **Enroll**, ** **and then select  **Finish**.
+7. In the  **Certificate Enrollment** wizard, select **Next** twice, select the **User** checkbox, select **Enroll**, and then select  **Finish**.
 
 8. In the  **Certificates** console, in the navigation pane, expand **Personal**, select  **Certificates**, in the details pane, verify that the  **Administrator** has a certificate, and then close the **Certificates** console.
 
-9. On the taskbar, select  **Start**, ** **type  **control**, and then select  **Control Panel**
+9. On the taskbar, select  **Start**, type:  **control**, and then select  **Control Panel**
 
-10. In  **Control Panel**, in the  **Search Control Panel** text box, type **printer**, ** **and then select  **Devices and Printers**.
+10. In  **Control Panel**, in the  **Search Control Panel** text box, type: **printer**, and then select  **Devices and Printers**.
 
-11. In  **Devices and Printers**, select  **Add a printer** and then select **The printer that I want isn’t listed**. The  **Add Printer** wizard ** **opens.
+11. In  **Devices and Printers**, select  **Add a printer** and then select **The printer that I want isn’t listed**. The  **Add Printer** wizard opens.
 
-12. On the  **Add Printer** page, select the **Select a shared printer by name** option, type **\\LON-DC1\Printer1** in the **Select a shared printer by name** text box, select **Next** twice, and then select **Finish**.
+12. On the  **Add Printer** page, select the **Select a shared printer by name** option, type: **\\\\LON-DC1\\Printer1** in the **Select a shared printer by name** text box, select **Next** twice, and then select **Finish**.
 
 13. Verify that after a few seconds,  **Microsoft PS Class Driver on lon-dc1** is added, and then close the **Devices and Printers** window.
 
-14. On  **LON-DC1**, in  **File Explorer**, verify that the  **C:\UEVdata** folder has a subfolder named **Administrator**.
+14. On  **LON-DC1**, in  **File Explorer**, verify that the  **C:\\UEVdata** folder has a subfolder named **Administrator**.
 
 15. In File Explorer, select the  **View** tab, select the **Hidden items** check box, double-click the **Administrator** folder, and then verify that it contains the **SettingsPackages** subfolder. Double-click the **SettingsPackages** folder, and then verify that it contains multiple subfolders for the applications and Windows settings that UE-V syncs.
+
 >  **Note:** The **SettingsPackages** folder includes the **MicrosoftWordpad6** subfolder, because WordPad stores its settings as soon as you close the app.
-16. On  **LON-CL1**, on the taskbar, select  **Start**, type  **wordpad**, and then press Enter.
+
+16. On  **LON-CL1**, on the taskbar, select  **Start**, type:  **wordpad**, and then press Enter.
 
 17. On the  **View** tab, verify that the **Ruler** and **Status bar** check boxes are not selected, which is not the default configuration, but it is exactly as you configured it on **LON-CL2**. Close WordPad.
 
-18. On  **LON-CL1**, in Windows PowerShell, type  **logoff**, ** **and then press Enter.
+18. On  **LON-CL1**, in Windows PowerShell, type:  **logoff**, and then press Enter.
 
-19. On  **LON-CL2**, in Windows PowerShell, type  **logoff**, ** **and then press Enter.
+19. On  **LON-CL2**, in Windows PowerShell, type:  **logoff**, and then press Enter.
 
-20. Sign in to  **LON-CL1** as **Adatum\Administrator** with the password **Pa55w.rd**.
+20. Sign in to  **LON-CL1** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
-21. On  **LON-CL1**, verify that a shortcut to  **Local Disk (C)** is not present on the desktop. You created it on the desktop on **LON-CL2**, and it is stored in the local user profile.
+21. On  **LON-CL1**, verify that a shortcut to  **Local Disk (C:)** is not present on the desktop. You created it on the desktop on **LON-CL2**, and it is stored in the local user profile.
+
 >  **Note:** UE-V does not sync desktop contents. Instead, you should use **Folder Redirection** or roaming user profiles to make data roam between computers.
-22. On  **LON-CL1**, on the taskbar, select  **Start**, type  **notepad**, and then press Enter.
+
+22. On  **LON-CL1**, on the taskbar, select  **Start**, type:  **notepad**, and then press Enter.
 
 23. In  **Notepad**, on the  **File** menu, select **Open**. In the navigation pane, expand  **This PC**, and then select  **Documents**.
 
-24. Verify that the file with your name is not available in the details pane. You created a file with your name on  **LON-CL2**, ** **and it is stored in the local user profile. Select  **Cancel**, and then close  **Notepad**.
+24. Verify that the file with  **_&lt;your name&gt;_** is not available in the details pane. You created a file with  **_&lt;your name&gt;_** on  **LON-CL2**, and it is stored in the local user profile. Select  **Cancel**, and then close  **Notepad**.
+
 >  **Note:** You should use **Folder Redirection** or roaming user profiles to make data roam between computers. UE-V syncs settings only, not data. The **Folder Redirection** GPO that you created earlier does not apply to the Administrator, because the Administrator is not in the **Marketing** OU.
-25. On the taskbar, select  **Start**, type  **certmgr.msc**, and then press Enter.
+
+25. On the taskbar, select  **Start**, type:  **certmgr.msc**, and then press Enter.
 
 26. In the  **Certificates** console, in the navigation pane, expand **Personal**, and then verify that no user certificate is present. UE-V sync certificates when a user signs out for the second time.
 
 27. On the taskbar, right-click  **Start**, select  **Shut down or sign out**, ** **and then select  **Sign out**.
 
-28. Sign in to  **LON-CL2** as **Adatum\Administrator** with the password **Pa55w.rd**, and then sign out immediately.
+28. Sign in to  **LON-CL2** as **Adatum\\Administrator** with the password **Pa55w.rd**, and then sign out immediately.
 
-29. Sign in to  **LON-CL1** as **Adatum\Administrator** with the password **Pa55w.rd**.
+29. Sign in to  **LON-CL1** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
-30. On the taskbar, select  **Start**, type  **certmgr.msc**, and then press Enter.
+30. On the taskbar, select  **Start**, type:  **certmgr.msc**, and then press Enter.
 
 31. In the  **Certificates** console, in the navigation pane, expand **Personal**, select  **Certificates**, in the details pane. verify that the  **Administrator** has the certificate and then close the **Certificates** console.
 
-32. On the taskbar, select  **Start**, ** **type  **printer**, and then select  **Printers &amp; scanners**.
+32. On the taskbar, select  **Start**, type:  **printer**, and then select  **Printers &amp; scanners**.
 
 33. In the  **Settings** app, on the **Printers &amp; scanners** page, verify that **Microsoft PS Class Driver on lon-dc1** is listed. This network printer was synced by UE-V. Close the **Settings** app.
 
@@ -380,25 +419,29 @@
 
 #### Task 6: Create and use custom UE-V template
   
-1. On  **LON-CL1**, on the taskbar, select  **Start**, type  **generator**, ** **and then select  **Microsoft User Experience Virtualization (UE-V)**.
+1. On  **LON-CL1**, on the taskbar, select  **Start**, type:  **generator**, and then select:  **Microsoft User Experience Virtualization (UE-V)**.
 
 2. On the  **Microsoft User Experience Virtualization** page, select **Create a settings location template**.
 
-3. On the  **Specify Application** page, select **Browse** for the **File path**, go to  **C:\Program Files (x86)\Microsoft\Remote Desktop Connection Manager**, select  **RDCMan.exe**, select  **Open**, and then select  **Next**.
+3. On the  **Specify Application** page, select **Browse** for the **File path**, go to:  
+**C:\\Program Files (x86)\\Microsoft\\Remote Desktop Connection Manager**,  
+select  **RDCMan.exe**, select  **Open**, and then select  **Next**.
+
 >  **Note:** You will create a settings location template for **Remote Desktop Connection Manager**.
+
 4. After a few seconds,  **Remote Desktop Connection Manager** opens. In **Remote Desktop Connection Manager**, select  **Tools**, ** **and then select  **Options**.
 
-5. In the  **Options** dialog box, on the **Tree** tab, select the **Click to select gives focus to remote client** check box, and then select **OK**. ** **Close  **Remote Desktop Connection Manager**.
+5. In the  **Options** dialog box, on the **Tree** tab, select the **Click to select gives focus to remote client** check box, and then select **OK**. Close **Remote Desktop Connection Manager**.
 
 6. In the  **Discover Locations** dialog box, select **Next**.
 
-7. On the  **Review Locations** page, select the **Files** tab, select **Nonstandard (2)**, ** **select the  **File path** checkbox for the location that includes **Remote Desktop Connection Manager**, and then select  **Next**.
+7. On the  **Review Locations** page, select the **Files** tab, select **Nonstandard (2)**, select the  **File path** checkbox for the location that includes **Remote Desktop Connection Manager**, and then select  **Next**.
 
-8. On the  **Edit Template** page, view the settings location template properties. You could modify the registry and files that are used for storing configuration data on this page. Select **Create**, in the  **File name** text box, type **\\LON-DC1\UEVTemplates\RDCMan.xml**, ** **and then ** **select  **Save**.
+8. On the  **Edit Template** page, view the settings location template properties. You could modify the registry and files that are used for storing configuration data on this page. Select **Create**, in the  **File name** text box, type: **\\\\LON-DC1\\UEVTemplates\\RDCMan.xml**, and then select  **Save**.
 
 9. In the  **Create a Settings Location Template Wizard**, on the  **Finish** page, select **Close**, and then close the  **Microsoft User Experience Virtualization** page.
 
-10. On  **LON-CL1**, on the taskbar, select  **Start**, type  **powershell**, and then press Enter.
+10. On  **LON-CL1**, on the taskbar, select  **Start**, type:  **powershell**, and then press Enter.
 
 11. In the Windows PowerShell command prompt, type the following command, and then press Enter: 
 
@@ -407,6 +450,7 @@
   ```
 
 >  **Note:** The output is empty, which shows that no settings location template that contains the string “rdc” is currently registered.
+
 12. Register the Remote Desktop Connection Manager settings location template by typing the following cmdlet, and then press Enter:
 
   ```
@@ -414,16 +458,19 @@
   ```
 
 >  **Note:** By default, the settings location template updates register once per day. By running the cmdlet, you are manually registering the template.
+
 13. To verify that the template is registered, type the following cmdlet, and then press Enter: 
 
   ```
   Get-UevTemplate *rdc* 
   ```
 
->  **Note:** You can see that the Remote Desktop Connection Manager template with **TemplateId Remote-Desktop-RDCMan-v-2-7** is listed.
-14. Sign in to  **LON-CL2** as **Adatum\Administrator** with the password **Pa55w.rd**.
+>  **Note:** You should see the Remote Desktop Connection Manager template with:  
+ **TemplateId Remote-Desktop-RDCMan-v-2-7** listed.
 
-15. On  **LON-CL2**, on the taskbar, select  **Start**, type  **powershell**, and then press Enter.
+14. Sign in to  **LON-CL2** as **Adatum\\Administrator** with the password **Pa55w.rd**.
+
+15. On  **LON-CL2**, on the taskbar, select  **Start**, type:  **powershell**, and then press Enter.
 
 16. Register the Remote Desktop Connection Manager settings location template by typing the following cmdlet, and the pressing Enter:
 
@@ -431,15 +478,15 @@
   Register-UevTemplate \\LON-DC1\UEVTemplates\RDCMan.xml 
   ```
 
-17. On  **LON-CL1**, on the taskbar, select  **Start**, type  **remote**, and then select  **Remote Desktop Connection Manager**.
+17. On  **LON-CL1**, on the taskbar, select  **Start**, type:  **remote**, and then select  **Remote Desktop Connection Manager**.
 
-18. In Remote Desktop Connection Manager v2.7, select  **Tools**, ** **and then select  **Options**. ** **
+18. In Remote Desktop Connection Manager v2.7, select  **Tools**, and then select  **Options**.
 
-19. In the  **Options** dialog box, ** **select the  **Auto save interval** check box, ** **and then in the  **minute(s)** text box, type **3**. Select  **OK**, ** **and then close Remote Desktop Connection Manager.
+19. In the  **Options** dialog box, select the  **Auto save interval** check box, and then in the  **minute(s)** text box, type: **3**. Select  **OK**, and then close Remote Desktop Connection Manager.
 
-20. On  **LON-CL2**, on the taskbar, select  **Start**, type  **remote**, and then select  **Remote Desktop Connection Manager**.
+20. On  **LON-CL2**, on the taskbar, select  **Start**, type:  **remote**, and then select  **Remote Desktop Connection Manager**.
 
-21. In Remote Desktop Connection Manager v2.7, select  **Tools**, select  **Options**, ** **and then verify that ** Auto save interval** is selected and is configured to **3 minute(s)**. Select  **OK**, ** **and then close Remote Desktop Connection Manager.
+21. In Remote Desktop Connection Manager v2.7, select  **Tools**, select  **Options**, and then verify that **Auto save interval** is selected and is configured to **3 minute(s)**. Select  **OK**, and then close Remote Desktop Connection Manager.
 
 22. To view the  **TemplateId** of the template, in Windows PowerShell, type the following cmdlet, and then press Enter:
 
@@ -447,18 +494,19 @@
   Get-UevTemplate *rdc* 
   ```
 
-23. To revert Remote Desktop Connection Manager ** **to its initial values, in Windows PowerShell, type the following cmdlet, and then press Enter:
+23. To revert Remote Desktop Connection Manager to its initial values, in Windows PowerShell, type the following cmdlet, and then press Enter:
 
   ```
   Restore-UevUserSetting Remote-Desktop-RDCMan-v-2-7
   ```
 
-24. On the taskbar, select  **Start**, type  **remote**, and then select  **Remote Desktop Connection Manager**.
+24. On the taskbar, select  **Start**, type:  **remote**, and then select  **Remote Desktop Connection Manager**.
 
-25. In Remote Desktop Connection Manager v2.7, select  **Tools**, select  **Options**, ** **and then verify that ** Auto save interval** is not enabled, which was the initial state. Select **OK**, ** **and then close Remote Desktop Connection Manager v2.7.
+25. In Remote Desktop Connection Manager v2.7, select  **Tools**, select  **Options**, and then verify that **Auto save interval** is not enabled, which was the initial state. Select **OK**, and then close Remote Desktop Connection Manager v2.7.
 
 
 >  **Result**: After completing this exercise, you should have successfully implemented and configured UE-V for syncing apps and Windows settings.
+
 
 
 ## Exercise 3: Configuring and using Enterprise State Roaming
@@ -467,26 +515,32 @@
   
 1. On  **LON-DC1**, on the taskbar, right-click  **Internet Explorer**, and then select  **Start InPrivate Browsing**.
 
-2. In Internet Explorer, in the address bar, type  **https://portal.azure.com** and press Enter **.**
+2. In Internet Explorer, in the address bar, type:  [**https://portal.azure.com**](https://portal.azure.com) and press Enter.
 
 3. On the  **Microsoft Azure** page, enter the Microsoft account credentials that you created in lab in module 3, and then select **Sign in**.
->  **Note:** If you followed the suggestion in the lab in Module 3, you created a Microsoft account in the format **&lt;YourInitials&gt;MMDDYY@outlook.com** and used **Pa55w.rd!** as the password. For example, if your name is Don Funk and you created Microsoft account on November 18, 2017, your account should be DF111817@outlook.com.
+
+>  **Note:** If you followed the suggestion in the lab in Module 3, you created a Microsoft account in the format **_&lt;YourInitials&gt;&lt;MMDDYY&gt;_@outlook.com** and used **Pa55w.rd!** as the password.  
+For example, if your name is Don Funk and you created Microsoft account on November 18, 2017, your account should be DF111817@outlook.com.
+
 4. In the Azure Portal, in the navigation pane, select  **Azure Active Directory**.
 
 5. In the  **Azure Active Directory** blade, in the navigation pane, select **Devices**.
 
 6. In the  **Devices** blade, make a note of devices that are listed in the details pane. In the navigation pane, select **Device settings**.
 
-7. In the  **Devices – Device settings** blade, in the details pane, in the **Users may sync settings and app data across devices** section, select **Selected**.
+7. In the  **Devices – Device settings** blade, in the details pane, in the  
+**Users may sync settings and app data across devices** section, select **Selected**.
 
-8. Click  **No member selected**, select  **+ Add members**, type  **Aidan** in the text box, select **Aidan Norman**, select  **Add**, select  **OK**, ** **and then select  **Save**. Make note of Aidan’s account, because you will need it in the next task.
+8. Click  **No member selected**, select  **+ Add members**, type:  **Aidan** in the text box, select **Aidan Norman**, select  **Add**, select  **OK**, and then select  **Save**.  
+Make note of Aidan’s account, because you will need it in the next task.
 
 >  **Note:** By performing this task, you enabled Enterprise State Roaming for Aidan Norman.
 
 
 #### Task 2: Add a computer to Azure AD
   
-1. In Hyper-V manager, right-click  **20697-2C-LON-CL5**, select  **Start**, and then double-click  **20697-2C-LON-CL5**.
+1. In Hyper-V manager, right-click  **20697-2C-LON-CL5**, select  **Start**, and then double-click   
+**20697-2C-LON-CL5**.
 
 2. On  **LON-CL5**, on the  **Let’s start with region. Is this right?** page, select **Yes**.
 
@@ -496,39 +550,45 @@
 
 5. On the  **Here’s the License Agreement** page, select **Accept**.
 
-6. On the  **Sign in with Microsoft** page, in the text box, type **Aidan@&lt;YourInitialsDDMMYY&gt;outlook.onmicrosoft.com**, ** **and then select  **Next**.
->  **Note:** If you followed the suggestion in Module 3, you created a Microsoft account in the format **&lt;YourInitials&gt;MMDDYY@outlook.com**. For example, if your name is Don Funk and you created Microsoft account on November 18, 2017, your account should be DF111817@outlook.com. In that case, you should type  **Aidan@DF111817outlook.onmicrosoft.com** as the account.
-7. On the  **Enter your password** page, type **Pa55w.rd**, ** **and then select  **Next**.
+6. On the  **Sign in with Microsoft** page, in the text box, type: **Aidan@*&lt;YourInitials&gt;&lt;DDMMYY&gt;*outlook.onmicrosoft.com**, and then select  **Next**.
 
-8. On the  **Choose privacy settings for your device** page, ** **select  **Accept**.
+>  **Note:** If you followed the suggestion in Module 3, you created a Microsoft account in the format **_&lt;YourInitials&gt;&lt;MMDDYY&gt;_@outlook.com**.  
+For example, if your name is Don Funk and you created Microsoft account on November 18, 2017, your account should be DF111817@outlook.com. In that case, you should type:  **Aidan@DF111817outlook.onmicrosoft.com** as the account.
 
-9. While the user is signing in to  **LON-CL5**, switch to  **LON-CL3**, and then sign in as the same user,  **Aidan@&lt;YourInitialsDDMMYY&gt;outlook.onmicrosoft.com**, and use  **Pa55w.rd** as the password.
+7. On the  **Enter your password** page, type: **Pa55w.rd**, and then select **Next**.
 
-10. On the  **Your organization requires Windows Hello** page, select **Set up PIN**, close the  **Help us protect your account** dialog box, ** **and then select  **Skip for now.**
+8. On the  **Choose privacy settings for your device** page, select **Accept**.
 
-11. On the taskbar, select  **Start**, type  **sync your**, ** **and then select  **Sync your settings**.
+9. While the user is signing in to  **LON-CL5**, switch to  **LON-CL3**, and then sign in as the same user,  **Aidan@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**, and use  **Pa55w.rd** as the password.
 
-12. In the  **Settings** app, on the **Sync your settings** page, verify that **Sync Settings** is **On**. Also verify that all individual sync settings are turned on and that you are using device as Aidan@&lt;YourInitialsDDMMYY&gt;outlook.onmicrosoft.com. Close the  **Settings** app.
+10. On the  **Your organization requires Windows Hello** page, select **Set up PIN**, close the  **Help us protect your account** dialog box, and then select **Skip for now.**
 
-13. On  **LON-CL5**, on the  **Your organization requires Windows Hello** page, select **Set up PIN**, close the  **Help us protect your account** dialog box, ** **and then select  **Skip for now.**
+11. On the taskbar, select  **Start**, type:  **sync your**, and then select  **Sync your settings**.
 
-14. On  **LON-CL5**, right-click on the desktop, select  **Personalize**, select one of the custom background pictures, and then close the  **Settings** app.
+12. In the  **Settings** app, on the **Sync your settings** page, verify that **Sync Settings** is **On**.  
+Also verify that all individual sync settings are turned on and that you are using device as Aidan@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com. Close the  **Settings** app.
+
+13. On  **LON-CL5**, on the  **Your organization requires Windows Hello** page, select **Set up PIN**, close the  **Help us protect your account** dialog box, and then select **Skip for now.**
+
+14. On  **LON-CL5**, right-click on the desktop, select  **Personalize**, select one of the custom background pictures, and then close the **Settings** app.
 
 
 
 #### Task 3: View device properties and sync status
   
-1. On  **LON-CL5**, on the taskbar, select  **Start**, type  **explorer**, ** **and select  **Internet Explorer**.
+1. On  **LON-CL5**, on the taskbar, select  **Start**, type:  **explorer**, and select **Internet Explorer**.
 
-2. In  **Internet Explorer**, in the address bar, type  **www.microsoft.com/learning**, and then press Enter. When the page loads, right-click on the page, select  **Add to favorites**, ** **and then select  **Add**.
+2. In  **Internet Explorer**, in the address bar, type: [**https://www.microsoft.com/learning**](https://www.microsoft.com/learning), and then press Enter. When the page loads, right-click on the page, select  **Add to favorites**, and then select  **Add**.
 
-3. On  **LON-CL3**, on the taskbar, select  **Start**, type  **explorer**, ** **and then select  **Internet Explorer**.
+3. On **LON-CL3**, on the taskbar, select **Start**, type: **explorer**, and then select **Internet Explorer**.
 
 4. In  **Internet Explorer**, select ALT+C to view favorites. Verify if  **Computer Training** favorites page is already synced from **LON-CL5**.
+
 >  **Note:** Usually, Enterprise State Roaming syncs settings fairly quickly.
+
 5. On  **LON-DC1**, in  **Internet Explorer**, on the  **Devices – Device settings** blade, in the navigation pane, select **All devices**.
 
-6. In the details pane, view devices. Be aware that in this exercise, you added a device whose name starts with  **DESKTOP-** to Azure AD.
+6. In the details pane, view devices. Notice that in this exercise, you added a device whose name starts with  **DESKTOP-** to Azure AD.
 
 7. In the details pane, in the  **OWNER** column, select **Aidan Norman.**
 
@@ -551,24 +611,29 @@
 4. In the  **GPMC**, delete the  **UE-V** Group Policy that is linked to the **Adatum.com** domain and **Folder Redirection** GPO that is linked to Marketing OU.
 
 5. Create a checkpoint of  **LON-CL5**, and name it  **After Lab 4A**. You can create checkpoint by performing following steps:
-In the 20697-2A-LON-CL5 window, select  **Action**, ** **and then select  **Checkpoint**.
 
-In  **Checkpoint name** dialog box, type **After Lab 4A**, select  **Yes**, ** **and then select  **OK**. 
+- In the 20697-2A-LON-CL5 window, select  **Action**, and then select  **Checkpoint**.
 
-6. Revert the  **LON-CL1**,  **LON-CL2**, and  **LON-CL5** virtual machines. _Do not revert LON-DC1!_ You can revert virtual machines by performing following steps:
-On the host computer, start Hyper-V Manager.
+- In  **Checkpoint name** dialog box, type: **After Lab 4A**, select  **Yes**, and then select  **OK**. 
 
-In the  **Virtual Machines** list, right-click **20697-2C-LON-CL1**, and then select  **Revert**.
+6. Revert the  **LON-CL1**,  **LON-CL2**, and  **LON-CL5** virtual machines. **_Do not revert LON-DC1!_**  
+You can revert virtual machines by performing following steps:
 
-In the  **Revert Virtual Machine** dialog box, select **Revert**.
+- On the host computer, start Hyper-V Manager.
 
-Repeat steps b and c for  **20697-2C-LON-CL2** and **20697-2C-LON-CL5**.
+- In the  **Virtual Machines** list, right-click **20697-2C-LON-CL1**, and then select  **Revert**.
 
-7. Shut down LON-CL3. Do not revert LON-CL3.
+- In the  **Revert Virtual Machine** dialog box, select **Revert**.
+
+- Repeat steps b and c for  **20697-2C-LON-CL2** and **20697-2C-LON-CL5**.
+
+7. Shut down **LON-CL3**. **_Do not revert LON-CL3_**.
 
 8. Shut down  **MT17B-WS2016-NAT**.
 
->  **Note:** Do not revert **LON-DC1**.  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.
+    >  **Note:** Do not revert **LON-DC1**.  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have successfully configured Enterprise State Roaming in Azure AD, joined a Windows 10 device to Azure AD, and performed a sync.
 
@@ -580,10 +645,9 @@ Repeat steps b and c for  **20697-2C-LON-CL2** and **20697-2C-LON-CL5**.
   
 #### Task 1: Create a custom XML migration file
   
-1. Sign in to  **LON-CL2** as **Adatum\Vera** with the password **Pa55w.rd**.
+1. Sign in to  **LON-CL2** as **Adatum\\Vera** with the password **Pa55w.rd**.
 
 2. Verify that Vera has a black desktop and following custom configuration:
-
 
   -  **This PC** and **Vera Pace** folders are on the desktop
 
@@ -591,28 +655,28 @@ Repeat steps b and c for  **20697-2C-LON-CL2** and **20697-2C-LON-CL5**.
 
   - Store and Mail apps are not pinned to the taskbar
 
+3. On the desktop, right-click anywhere, select  **New**, select  **Text Document**, type:  **_&lt;your name&gt;_**, and then press Enter.
 
-3. On the desktop, right-click anywhere, select  **New**, select  **Text Document**, type  _your name,_ and then press Enter.
+4. On the taskbar, select  **File Explorer**. In File Explorer, in the navigation pane, expand  **This PC**, expand  **Local Disk (C:)**, expand  **Users**, expand  **Public**, and then select  **Public Documents**. In the details pane, right-click anywhere, select  **New**, select  **Text Document**, type:  **Vera’s Public Documents**, and then press Enter.
 
-4. On the taskbar, select  **File Explorer**. In File Explorer, in the navigation pane, expand  **This PC**, expand  **Local Disk (C:)**, expand  **Users**, expand  **Public**, ** **and then select  **Public Documents**. In the details pane, right-click anywhere, select  **New**, select  **Text Document**, type  **Vera’s Public Documents**, and then press Enter.
+5. In the navigation pane, select  **Public Music**, in the details pane, right-click anywhere, select  **New**, select  **Text Document**, type:  **Vera’s Public Music** and then press Enter.
 
-5. In the navigation pane, select  **Public Music**, in the details pane, right-click anywhere, select  **New**, select  **Text Document**, type  **Vera’s Public Music** and then press Enter.
+6. Sign out of  **LON-CL2**, and then sign in to LON-CL2 as  **Adatum\\Administrator** with the password **Pa55w.rd**.
 
-6. Sign out of  **LON-CL2**, ** **and then sign in to LON-CL2 as  **Adatum\Administrator** with the password **Pa55w.rd**.
-
-7. On the taskbar, right-click  **Start**, ** **and then select  **Windows PowerShell**.
+7. On the taskbar, right-click  **Start**, and then select  **Windows PowerShell**.
 
 8. In Windows PowerShell, type the following three commands, pressing Enter after each command:
 
-  ```
-  Net Use F: \\LON-DC1\USMT
-F:
-F:\scanstate /i:migapp.xml /i:miguser.xml /genconfig:Config.xml
-  ```
+    ```
+    Net Use F: \\LON-DC1\USMT
+    F: 
+    F:\scanstate /i:migapp.xml /i:miguser.xml /genconfig:Config.xml
+    ```
+
 
 >  **Note:** The creation of the **Config.xml** file begins. Wait until the command finishes.
 
-9. In Windows PowerShell, type ** notepad Config.xml**, and then press Enter.
+9. In Windows PowerShell, type: **notepad Config.xml**, and then press Enter.
 
 10. To verify that the content of  **Shared Documents** will be migrated, under the **Documents** node, make sure that the **migrate** attribute for **Shared Documents** is set to **yes**. The line should be similar to the following:
 
@@ -620,51 +684,49 @@ F:\scanstate /i:migapp.xml /i:miguser.xml /genconfig:Config.xml
   component displayname="Shared Documents" migrate="yes"
   ```
 
-11. To exclude  **Shared Music** from the migration, under the **Documents** node, modify the **migrate** attribute for Shared Music to value **“no”**. The line should look as shown here:
+11. To exclude  **Shared Music** from the migration, under the **Documents** node, modify the **migrate** attribute for Shared Music to value **"no"**. The line should look as shown here:
 
   ```
   component displayname="Shared Music" migrate="no"
   ```
 
-12. To exclude Windows Defender settings from the migration, select  **Edit**, select  **Find**, type  **defender**, select  **Find Next**, ** **and then modify the  **migrate** attribute for **Windows-Defender-AM-Sigs** to value **“no”**.
+12. To exclude Windows Defender settings from the migration, select  **Edit**, select  **Find**, type:  **defender**, select  **Find Next**, and then modify the  **migrate** attribute for **Windows-Defender-AM-Sigs** to value **"no"**.
 
 13. Repeat the previous step and modify the  **migrate** attribute from yes to **no** for following two components:
-
 
   - Windows-Defender-AM-Engine
 
   - Security-Malware-Windows-Defender
 
+14. Close Notepad, and then select  **Save**.
 
-14. Close Notepad, ** **and then select  **Save**. ** **
-
-15. In Windows PowerShell, type  **notepad folders.xml**, and then press Enter.  **Folders.xml** is a custom XML file that will be used to migrate a folder named **Projects** to the new computer.
+15. In Windows PowerShell, type:  **notepad folders.xml**, and then press Enter.  **Folders.xml** is a custom XML file that will be used to migrate a folder named **Projects** to the new computer.
 
 16. Change the  **&lt;Foldername&gt;** string to **Projects**. Do not forget to replace the  **&lt;** and **&gt;** symbols. The entire line should look similar to the following:
 
   ```
-  &lt;pattern type= "File"&gt;C:\Projects\* [*]&lt;/pattern&gt;
+  <pattern type= "File">C:\Projects\* [*]</pattern>
   ```
 
-17. Close Notepad, and then select  **Save**. ** **
+17. Close Notepad, and then select  **Save**.
 
 18. On the taskbar, select  **File Explorer**.
 
 19. In File Explorer, in the navigation pane, expand  **This PC**, and then select  **Local Disk (C:)**. In the details pane, double-click  **Projects**, and then verify that files named  **Project1.txt** and **Project2.txt** are in the folder.
 
-20. In File Explorer, right-click in the details pane, select  **New**, select  **Text Document**, type _ _your name, and then press Enter _._
+20. In File Explorer, right-click in the details pane, select  **New**, select  **Text Document**, type: **_&lt;your name&gt;_**, and then press Enter.
 
 
 
 #### Task 2: Capture the user state
   
-1. On  **LON-CL2**, in File Explorer, right-click  **This PC**, ** **and then select  **Manage**.
+1. On  **LON-CL2**, in File Explorer, right-click  **This PC**, and then select  **Manage**.
 
 2. In Computer Management, in the navigation pane, expand  **Local Users and Groups**, and then select  **Users**.
 
 3. In the details pane, verify that user named  **LocalAdmin** is listed, and then close **Computer Management**.
 
-4. In Windows PowerShell, verify that no content is on the  **\\LON-DC1\MigStore** shared folder, by typing the following command and then pressing Enter:
+4. In Windows PowerShell, verify that no content is on the  **\\\\LON-DC1\\MigStore** shared folder, by typing the following command and then pressing Enter:
 
   ```
   Dir \\lon-dc1\MigStore
@@ -678,7 +740,6 @@ F:\scanstate /i:migapp.xml /i:miguser.xml /genconfig:Config.xml
 
 6. Wait until ScanState finishes, and then verify that the user state is captured in the shared folder by typing the following command and then pressing Enter: 
 
-
 ```
 Dir \\lon-dc1\MigStore -Recurse
 ```
@@ -687,11 +748,12 @@ Dir \\lon-dc1\MigStore -Recurse
 >  **Result**: After completing this exercise, you should have created and customized XML files to use with the USMT.
 
 
+
 ## Exercise 2: Restore the user state on the destination computer
   
 #### Task 1: Restore the user state
   
-1. Sign in to  **LON-CL1** as **Adatum\Administrator** with the password **Pa55w.rd**.
+1. Sign in to  **LON-CL1** as **Adatum\\Administrator** with the password **Pa55w.rd**.
 
 2. On  **LON-CL1**, on the taskbar, select  **File Explorer**.
 
@@ -699,7 +761,7 @@ Dir \\lon-dc1\MigStore -Recurse
 
 4. In File Explorer, in the navigation pane, select  **Local Disk (C:)**, and then in the details pane, verify that there is no folder named  **Projects**.
 
-5. On the taskbar, right-click  **Start**, ** **and then select  **Computer Management**.
+5. On the taskbar, right-click  **Start**, and then select  **Computer Management**.
 
 6. In Computer Management, in the navigation pane, expand  **Local Users and Groups**, and then select  **Users**.
 
@@ -713,7 +775,7 @@ Dir \\lon-dc1\MigStore -Recurse
   Net Use F: \\LON-DC1\USMT
   ```
 
-10. In Windows PowerShell, type  **F:**, and then press Enter.
+10. In Windows PowerShell, type:  **F:**, and then press Enter.
 
 11. In Windows PowerShell, type the following command, press Enter, and then wait for LoadState to finish:
 
@@ -723,7 +785,7 @@ Dir \\lon-dc1\MigStore -Recurse
 
 12. On the taskbar, select  **File Explorer**.
 
-13. In File Explorer, in the navigation pane, expand  **Local Disc (C:)**, expand ** Users**, ** **and then verify that the subfolder named  **Vera** now exists.
+13. In File Explorer, in the navigation pane, expand  **Local Disc (C:)**, expand **Users**, and then verify that the subfolder named  **Vera** now exists.
 
 14. On the taskbar, right-click  **Start**, and then select  **Computer Management**.
 
@@ -737,10 +799,9 @@ Dir \\lon-dc1\MigStore -Recurse
 
 #### Task 2: Verify migration of user settings
   
-1. Sign in to  **LON-CL1** as **Adatum\Vera** with the password **Pa55w.rd**. 
+1. Sign in to  **LON-CL1** as **Adatum\\Vera** with the password **Pa55w.rd**. 
 
-2. Verify that Vera has a black desktop, file with your name on the desktop and the same customizations as on  **LON-CL2**:
-
+2. Verify that Vera has a black desktop, file with  **_&lt;your name&gt;_** on the desktop and the same customizations as on  **LON-CL2**:
 
   -  **This PC** and **Vera Pace** folders are on the desktop
 
@@ -748,10 +809,9 @@ Dir \\lon-dc1\MigStore -Recurse
 
   - Store and Mail apps are not pinned to the taskbar
 
-
 3. On the taskbar, select  **File Explorer**.
 
-4. In File Explorer, in the navigation pane, expand  **This PC**, expand  **Local Disk (C:)**, select  **Projects**, and then in the details pane, verify that all files from  **LON-CL2** have migrated, including the file with your name.
+4. In File Explorer, in the navigation pane, expand  **This PC**, expand  **Local Disk (C:)**, select  **Projects**, and then in the details pane, verify that all files from  **LON-CL2** have migrated, including the file with  **_&lt;your name&gt;_**.
 
 5. In the navigation pane, expand  **Users**, expand  **Public**, select  **Public Documents**, and then in the details pane, verify that  **Vera’s Public Documents** appears.
 
@@ -761,7 +821,7 @@ Dir \\lon-dc1\MigStore -Recurse
 
 #### Task 3: Prepare for the next module
   
- When you are finished with the lab, revert the  **LON-CL1** and ** LON-CL2** virtual machines to their initial state. **Do not revertLON-DC1!**: 
+ When you are finished with the lab, revert the  **LON-CL1** and **LON-CL2** virtual machines to their initial state. **_Do not revertLON-DC1!_** 
 
 1. On the host computer, start  **Hyper-V Manager**.
 
@@ -771,7 +831,10 @@ Dir \\lon-dc1\MigStore -Recurse
 
 4. Repeat steps 2 and 3 for  **20697-2C-LON-CL2**.
 
->  **Note:** Do not revert **LON-DC1**!  **LON-DC1** is synchronizing on-premises AD DS with Azure AD. You can shut down LON-DC1.
+    >  **Note:** **_Do not revert LON-DC1!_**  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.  
+ You can shut down LON-DC1.
+
+<!-- -->
 
 >  **Result**: After performing this exercise, you will restore user state on destination computer.
 

--- a/Instructions/206972C_LAB_AK_04.md
+++ b/Instructions/206972C_LAB_AK_04.md
@@ -306,7 +306,7 @@ Double-click the  **Redirect folders on primary computers only** policy setting,
 
 >  **Note:** Notice that **SyncMethod** is set to **SyncProvider**. This means that UE-V is using the local setting cache, which is synced with the shared network folder every 30 minutes.
 
-4. View all UE-V Windows PowerShell cmdlets by running the  **Get-Command –Module UEV** cmdlet.
+4. View all UE-V Windows PowerShell cmdlets by running the  **Get-Command -Module UEV** cmdlet.
 
 5. In  **Windows PowerShell**, type:  **notepad**, and then press Enter.
 
@@ -320,7 +320,7 @@ Double-click the  **Redirect folders on primary computers only** policy setting,
 
 >  **Note:** UE-V uses the local settings cache by default. This is the reason why changes from **LON-CL1** are not used on **LON-CL2** yet.
 
-10. In Windows PowerShell, type:  **Set-UevConfiguration–SyncMethod None** to configure UE-V to read settings directly from the network instead from the local settings cache, and then press Enter.
+10. In Windows PowerShell, type:  **Set-UevConfiguration-SyncMethod None** to configure UE-V to read settings directly from the network instead from the local settings cache, and then press Enter.
 
 11. In Windows PowerShell, type:  **notepad**, and then press Enter.
 
@@ -328,7 +328,7 @@ Double-click the  **Redirect folders on primary computers only** policy setting,
 
 13. In Notepad, select  **Format**, select  **Font**, select  **Arial** font, select Size **26**, select  **OK**, and then close Notepad without saving changes.
 
-14. On  **LON-CL1**, in Windows PowerShell, type:  **Set-UevConfiguration–SyncMethodNone**, and then press Enter.
+14. On  **LON-CL1**, in Windows PowerShell, type:  **Set-UevConfiguration-SyncMethodNone**, and then press Enter.
 
 15. In Windows PowerShell, type:  **notepad**, and then press Enter.
 

--- a/Instructions/206972C_LAB_AK_05.md
+++ b/Instructions/206972C_LAB_AK_05.md
@@ -1,4 +1,4 @@
-# Lab Answer Key:  Module 5: Managing desktop and application settings by using Group Policy
+﻿# Lab Answer Key:  Module 5: Managing desktop and application settings by using Group Policy
 # Lab: Configuring Group Policy policies and Group Policy preferences
   
 ## Exercise 1: Managing Windows 10 by using Group Policy
@@ -11,33 +11,34 @@
 
 3. In the details pane, right-click  **Mod05-Preparation.ps1**, and then select  **Run with PowerShell**.
 
-4. Sign in to  **LON-CL2** as **Adatum\Beth** with the password **Pa55w.rd**.
+4. Sign in to  **LON-CL2** as **Adatum\\Beth** with the password **Pa55w.rd**.
 
-5. On the taskbar, select  **Start**, type  **policy**, ** **and then verify that  **Group Policy Management** is not listed.
+5. On the taskbar, select  **Start**, type  **policy**, and then verify that  **Group Policy Management** is not listed.
 
-6. On the taskbar, right-click  **Start**, select  **Windows PowerShell**, type  **mmc**, ** **and then press Enter.
+6. On the taskbar, right-click  **Start**, select  **Windows PowerShell**, type  **mmc**, and then press Enter.
 
-7. In  **Console1**, select  **File**, select  **Add/Remove Snap-in**, ** **and then verify that in Available snap-ins section there is only one snap-in that starts with words  **Group Policy**. Also verify that  **Resultant Set of Policy** snap-in is available, select **Cancel**, ** **and close Console1.
+7. In  **Console1**, select  **File**, select  **Add/Remove Snap-in**, and then verify that in Available snap-ins section there is only one snap-in that starts with words  **Group Policy**.  
+Also verify that  **Resultant Set of Policy** snap-in is available, select **Cancel**, and close Console1.
 
-8. In Windows PowerShell, type  **Get-Command *gpo***, ** **and then press Enter to list all commands that include the letters  **gpo**. Only three commands are listed, and they are not from GroupPolicy module.
+8. In Windows PowerShell, type  **Get-Command \*gpo\***, and then press Enter to list all commands that include the letters  **gpo**. Only three commands are listed, and they are not from GroupPolicy module.
 
 9. Verify that Beth’s desktop is black.
 
 10. On the taskbar, select  **Start**, type  **screen saver**, and then select  **Change screen saver**.
 
-11. In the  **Screen Saver Settings** dialog box, verify that the **On resume, display logon screen** check box is not selected and not grayed out. Verify that if you select any screen saver, you can modify the value in the **Wait** text box, and then select **Cancel**.
+11. In the  **Screen Saver Settings** dialog box, verify that the **On resume, display logon screen** check box is not selected and not grayed out. Verify that if you select any screen saver, you can modify the value in the **Wait:** text box, and then select **Cancel**.
 
-12. On  **LON-CL1**, on the taskbar, right-click  **Start**, select  **Windows PowerShell**, type  **mmc**, ** **and then press Enter.
+12. On  **LON-CL1**, on the taskbar, right-click  **Start**, select  **Windows PowerShell**, type  **mmc**, and then press Enter.
 
-13. In  **Console1**, select  **File**, select  **Add/Remove Snap-in**, ** **and then verify that in the  **Available snap-ins** section, there are four snap-ins that starts with words **Group Policy**. Select  **Cancel**, ** **and then close  **Console1**.
+13. In  **Console1**, select  **File**, select  **Add/Remove Snap-in**, and then verify that in the  **Available snap-ins** section, there are four snap-ins that starts with words **Group Policy**. Select  **Cancel**, and then close  **Console1**.
 
-14. In Windows PowerShell, type  **Get-Command *gpo***, ** **and then press Enter to list all commands that include the letters  **gpo**. This time, the output is longer and many of those commands are from the  **GroupPolicy** Windows PowerShell module.
+14. In Windows PowerShell, type  **Get-Command \*gpo\***, and then press Enter to list all commands that include the letters  **gpo**. This time, the output is longer and many of those commands are from the  **GroupPolicy** Windows PowerShell module.
 
-15. On the taskbar, select  **Start**, type  **users**, ** **and then select  **Active Directory Users and Computers**.
+15. On the taskbar, select  **Start**, type  **users**, and then select  **Active Directory Users and Computers**.
 
-16. In Active Directory Users and Computers, in the navigation pane, expand  **Adatum.com**, expand  **IT**, ** **and then select  **Technicians**. In the details pane, verify that  **Beth Burke** is listed.
+16. In Active Directory Users and Computers, in the navigation pane, expand  **Adatum.com**, expand  **IT**, and then select  **Technicians**. In the details pane, verify that  **Beth Burke** is listed.
 
-17. On the taskbar, select  **Start**, type  **policy management**, ** **and then select  **Group Policy Management**.
+17. On the taskbar, select  **Start**, type  **policy management**, and then select  **Group Policy Management**.
 
 
 
@@ -51,7 +52,7 @@
 
 4. In the Group Policy Management Editor, in the navigation pane, expand  **Policies** under User Configuration, expand **Administrative Templates**, expand  **Desktop**, and then select the  **Desktop** node below.
 
-5. In the details pane, double-click  **Desktop Wallpaper**, select  **Enabled**, and in the  **Wallpaper Name** text box, type **\\LON-DC1\Labfiles\Mod05\img1.jpg**, ** **and then select  **OK**.
+5. In the details pane, double-click  **Desktop Wallpaper**, select  **Enabled**, and in the  **Wallpaper Name** text box, type  **\\\\LON-DC1\\Labfiles\\Mod05\\img1.jpg**, and then select  **OK**.
 
 6. In the navigation pane, expand  **Control Panel**, and then select  **Personalization**.
 
@@ -59,19 +60,19 @@
 
 8. In the details pane, double-click  **Password protect the screen saver**, select  **Enabled**, select  **OK**, and then close Group Policy Management Editor.
 
-9. On  **LON-CL2**, on the taskbar, right-click  **Start**, select  **Shut down or sign out**, select  **Sign out** and then sign in as **Adatum\Beth** with the password **Pa55w.rd**.
+9. On  **LON-CL2**, on the taskbar, right-click  **Start**, select  **Shut down or sign out**, select  **Sign out** and then sign in as **Adatum\\Beth** with the password **Pa55w.rd**.
 
 10. Verify that desktop is no longer black and that image is displayed instead. This is the image you specified in  **Background1** GPO.
 
 11. On the taskbar, select  **Start**, type  **screen saver**, and then select  **Change screen saver**.
 
-12. On Screen Saver Settings dialog box, verify that the  **On resume, display logon screen** check box is selected and Wait is set to 31 minutes, which is 1860 seconds. Also verify that both settings are greyed out and you cannot change them, because they were set in the GPO. Select **Cancel**.
+12. On Screen Saver Settings dialog box, verify that the  **On resume, display logon screen** check box is selected and **Wait:** is set to 31 minutes, which is 1860 seconds. Also verify that both settings are greyed out and you cannot change them, because they were set in the GPO. Select **Cancel**.
 
 13. On  **LON-CL1**, in the  **GPMC**, in the navigation pane, expand  **Group Policy Objects**, right-click  **Background1**, and then select  **Copy**, 
 
 14. In the  **GPMC**, right-click  **Group Policy Objects**, select  **Paste**, and then select  **OK** twice.
 
-15. Right-click  **Copy of Background1**, select  **Rename**, type  **Background2**, ** **and then press Enter.
+15. Right-click  **Copy of Background1**, select  **Rename**, type  **Background2**, and then press Enter.
 
 16. Right-click  **Background2**, and then select  **Edit**.
 
@@ -79,11 +80,11 @@
 
 18. In the details pane, double-click  **Desktop Wallpaper**. Verify that the setting is already enabled, as it was enabled in the source GPO from which  **Backgrount2** was copied.
 
-19. In the  **Wallpaper Name** text box, change the value to **\\LON-DC1\Labfiles\Mod05\Img8.jpg**, ** **select  **OK**, and then close Group Policy Management Editor.
+19. In the  **Wallpaper Name** text box, change the value to **\\\\LON-DC1\\Labfiles\\Mod05\\Img8.jpg**, select  **OK**, and then close Group Policy Management Editor.
 
-20. In the  **GPMC**, in the navigation pane, right-click  **Technicians**, select  **Link an Existing GPO**, and in the  **Group Policy object** section, select **Background2**, ** **and then select  **OK**.
+20. In the  **GPMC**, in the navigation pane, right-click  **Technicians**, select  **Link an Existing GPO**, and in the  **Group Policy object** section, select **Background2**, and then select  **OK**.
 
-21. On  **LON-CL2**, on the taskbar, right-click  **Start**, select  **Shut down or sign out**, select  **Sign out**, and then sign in as  **Adatum\Beth** with the password **Pa55w.rd**.
+21. On  **LON-CL2**, on the taskbar, right-click  **Start**, select  **Shut down or sign out**, select  **Sign out**, and then sign in as  **Adatum\\Beth** with the password **Pa55w.rd**.
 
 22. Verify that the background has changed and it is now a picture of a flower, as you set it in the  **Background2** GPO. That GPO is linked to the OU that contains Beth’s account. Because of that, it has overwritten settings from the **Background1** GPO.
 
@@ -101,7 +102,7 @@
 
 4. In the navigation pane, verify that a blue exclamation mark is added to Technicians OU because you set block inheritance. In the details pane, verify that no GPO is listed on Group Policy Inheritance tab.
 
-5. On  **LON-CL2**, on the taskbar, right-click  **Start**, select  **Shut down or sign out**, select  **Sign out** and then sign in as **Adatum\Beth** and use **Pa55w.rd** as her password.
+5. On  **LON-CL2**, on the taskbar, right-click  **Start**, select  **Shut down or sign out**, select  **Sign out** and then sign in as **Adatum\\Beth** and use **Pa55w.rd** as her password.
 
 6. Verify that Beth’s background changed to black, as neither Background1 nor Background2 GPOs are applying to her.
 
@@ -115,7 +116,7 @@
 
 11. In the details pane, on the Group Policy Inheritance tab, verify that Background1 GPO has precedence of 1, even if it is linked to higher OU than Background2. This is because Background1 GPO link is enforced.
 
-12. On  **LON-CL2**, on the taskbar, right-click  **Start**, select  **Shut down or sign out**, select  **Sign out** and then sign in as **Adatum\Beth** and use **Pa55w.rd** as her password.
+12. On  **LON-CL2**, on the taskbar, right-click  **Start**, select  **Shut down or sign out**, select  **Sign out** and then sign in as **Adatum\\Beth** and use **Pa55w.rd** as her password.
 
 13. Verify that after a few seconds, Beth’s background changes to the image of a person running, which is configured in  **Background1 GPO**.
 
@@ -127,17 +128,19 @@
 
 2. In the  **Group Policy Results Wizard**, select  **Next**, select the  **Another computer** check box, type **LON-CL2** in the text box, and then select **Next**.
 
-3. On the  **User Selection** page, verify that you can select only among users that have already signed in to **LON-CL2**. For example, user  **Adatum\Tia** is not listed and you cannot select her, although this user exists in the Adatum domain. Verify that **ADATUM\Beth** is selected, select **Next** twice, and then select **Finish**.
+3. On the  **User Selection** page, verify that you can select only among users that have already signed in to **LON-CL2**. For example, user  **Adatum\\Tia** is not listed and you cannot select her, although this user exists in the Adatum domain. Verify that **ADATUM\\Beth** is selected, select **Next** twice, and then select **Finish**.
 
-4. In the  **GPMC**, in the navigation pane, verify that  **Beth on lon-cl2** node is added under Group Policy Results. In the details pane, select **Details** tab.
+4. In the  **GPMC**, in the navigation pane, verify that the **Beth on lon-cl2** node is added under Group Policy Results. In the details pane, select **Details** tab.
 
 5. In the details pane, select  **show all**. Scroll down to the  **User Details** section, which is toward the end of the report. In that section, find information that **Background1** is the winning GPO, and that it sets **Screen Saver Timeout** to **1860** seconds.
 
 6. In the  **GPMC**, in the navigation pane, right-click  **Beth on lon-cl2**, and then select  **Advanced View**. The  **Resultant Set of Policy** snap-in opens.
 
 7. In  **Resultant Set of Policy**, expand  **Administrative Templates** in **User Configuration**, expand  **Desktop,** and then select **Desktop** below.
+
 >  **Note:** Notice that only the **Control Panel** and **Desktop** nodes appear under **Administrative Templates**. This is because you configure GPO settings only in those two nodes.
-8. In the details pane, double-click  **Desktop Wallpaper**. Verify that on Settings tab you can view setting that was applied. Select  **Precedence** tab, verify that it lists all GPOs that have this settings configured, select **Cancel**, ** **close Resultant Set of Policy, and then select  **No**.
+
+8. In the details pane, double-click  **Desktop Wallpaper**. Verify that on Settings tab you can view setting that was applied. Select  **Precedence** tab, verify that it lists all GPOs that have this settings configured, select **Cancel**, close Resultant Set of Policy, and then select  **No**.
 
 9. In the  **GPMC**, in the navigation pane, right-click  **Group Policy Modeling**, and then select  **Group Policy Modeling Wizard**.
 
@@ -146,11 +149,13 @@
 11. On  **User and Computer Selection** page, select the **User** check box, in the **User information** section, select **Browse**, type  **tia**, and then select  **OK**. In the  **Computer information** section, select **Browse**, expand  **Adatum**, select  **Computers**, select  **OK** and then select **Next**.
 
 12. In the  **Group Policy Modeling Wizard**, review the settings that you can configure on each page, select  **Next** seven times, and then select **Finish**.
+
 >  **Note:** In the **Group Policy Modeling Wizard**, you can configure many additional settings, which you cannot set when you run the  **Group Policy Results Wizard**. The  **Group Policy Results Wizard** shows what happened in the past and you cannot influence that, whereas the **Group Policy Modeling Wizard** shows what will happen under some assumptions and you can specify those assumptions.
-> .
+
 13. In the  **GPMC**, in the navigation pane, verify that the  **Tia on Computers** node is added under **Group Policy Modeling**. In the details pane, select the  **Details** tab.
 
-14. In the details pane, select  **show all**. Scroll down to the  **User Details** section, which is toward the end of the report. Verify that no user setting would apply, because Tia’s account is in the **Research** OU and neither **Background1** nor **Background2** GPOs apply to that OU.
+14. In the details pane, select  **show all**. Scroll down to the  **User Details** section, which is toward the end of the report.  
+Verify that no user setting would apply, because Tia’s account is in the **Research** OU and neither **Background1** nor **Background2** GPOs apply to that OU.
 
 
 
@@ -158,33 +163,36 @@
   
 1. On  **LON-CL1**, in the  **GPMC**, in the navigation pane, right-click  **Background1** GPO and then select **Edit**.
 
-2. In Group Policy Management Editor, in the navigation pane, expand  **Policies** under Computer Configuration, verify that Administrative Template nodes states that policy definitions are retrieved from the local computer and then close Group Policy Management Editor.
+2. In Group Policy Management Editor, in the navigation pane, expand  **Policies** under Computer Configuration, verify that the Administrative Template nodes state that **policy definitions are retrieved from the local computer** and then close Group Policy Management Editor.
 
 3. On the taskbar, select  **File Explorer**.
 
 4. In File Explorer, in the navigation pane, expand  **This PC**, expand  **Local Disk (C:)**, and then select  **Windows**. In the details pane, right-click  **PolicyDefinitions** folder, and then select **Copy**.
 
-5. In File Explorer, in the address bar, select the down arrow, type  **\\LON-DC1\sysvol**, ** **and then press Enter.
+5. In File Explorer, in the address bar, select the down arrow, type  **\\\\LON-DC1\\sysvol**, and then press Enter.
 
 6. In the details pane, double-click  **Adatum.com**, double-click  **Policies**, right-click an empty space, and then select  **Paste**. 
+
 >  **Note:** You copied local copy of administrative templates to a domain controller and created central store.
+
 7. In the  **GPMC**, in the navigation pane, right-click  **Background1** GPO and then select **Edit**.
 
-8. In Group Policy Management Editor, in the navigation pane, expand  **Policies** under **Computer Configuration** and verify that **Administrative Template** nodes states that policy definitions were retrieved from the central store.
+8. In Group Policy Management Editor, in the navigation pane, expand  **Policies** under **Computer Configuration** and verify that the **Administrative Template** nodes state that **policy definitions were retrieved from the central store**.
 
-9. In the navigation pane, expand  **Administrative Templates** and verify that Microsoft Office 2016 (Machine) node is not present. Expand **Windows Components**, verify that  **Microsoft User Experience Virtualization** node is present, and then close Group Policy Management Editor.
+9. In the navigation pane, expand  **Administrative Templates** and verify that the:  
+**Microsoft Office 2016 (Machine)** node *is not* present. Expand **Windows Components**, verify that the **Microsoft User Experience Virtualization** node *is* present, and then close Group Policy Management Editor.
 
-10. On the taskbar, right-click  **File Explorer**, select  **File Explorer** and navigate to **E:\Labfiles\Mod05\admx** folder. In the details pane, select **word16.admx**, press and hold SHIFT, and then select the topmost folder to select all of its contents. Right-click selected files, and then select  **Copy**.
+10. On the taskbar, right-click  **File Explorer**, select  **File Explorer** and navigate to **E:\\Labfiles\\Mod05\\admx** folder. In the details pane, select **word16.admx**, press and hold **SHIFT**, and then select the topmost folder to select all of its contents. Right-click selected files, and then select  **Copy**.
 
 11. On the taskbar, select  **File Explorer**, select  **Policies** thumbnail, in the details pane, double-click **PolicyDefinitions**, right-click and then select  **Paste**.
 
-12. In the details pane, right-click  **UserExperienceVirutalization.admx** file, select **Delete**, ** **and then select  **Yes**.
+12. In the details pane, right-click  **UserExperienceVirutalization.admx** file, select **Delete**, and then select  **Yes**.
 
 13. On  **LON-CL1**, in the  **GPMC**, in the navigation pane, right-click  **Background1** GPO and then select **Edit**.
 
-14. In Group Policy Management Editor, in the navigation pane, expand  **Policies** under **Computer Configuration**, expand  **Administrative Templates** and verify that **Microsoft Office 2016 (Machine)** node is now present.
+14. In Group Policy Management Editor, in the navigation pane, expand  **Policies** under **Computer Configuration**, expand  **Administrative Templates** and verify that the **Microsoft Office 2016 (Machine)** node is now present.
 
-15. In the navigation pane, expand  **Windows Components**, verify that  **Microsoft User Experience Virtualization** node is not present and then close Group Policy Management Editor.
+15. In the navigation pane, expand  **Windows Components**, verify that the **Microsoft User Experience Virtualization** node is not present and then close Group Policy Management Editor.
 
 16. On  **LON-DC1**, on the taskbar, select  **Server Manager**.
 
@@ -192,23 +200,29 @@
 
 18. In the  **GPMC**, in the navigation pane, expand  **Forest: Adatum.com**, expand  **Domains**, expand  **Adatum.com** and expand **IT** OU. Right-click **Background1** GPO and then select **Edit**.
 
-19. In Group Policy Management Editor, in the navigation pane, expand  **Policies** under **Computer Configuration** and verify that **Administrative Template** nodes depict that policy definitions were retrieved from the central store.
+19. In Group Policy Management Editor, in the navigation pane, expand  **Policies** under **Computer Configuration** and verify that the **Administrative Template** nodes depict that policy definitions were **retrieved from the central store**.
 
-20. In the navigation pane, expand  **Administrative Templates** and verify that **Microsoft Office 2016 (Machine)** node is present, because all domain computers use administrative templates from the central store.
+20. In the navigation pane, expand  **Administrative Templates** and verify that the:  
+**Microsoft Office 2016 (Machine)** node *is* present, because all domain computers use administrative templates from the central store.
 
-21. In the navigation pane, expand  **Windows Components**, verify that  **Microsoft User Experience Virtualization** node is not present because you deleted the administrative template for UE-V and then close the Group Policy Management Editor and **GPMC**.
+21. In the navigation pane, expand  **Windows Components**, verify that the:  
+**Microsoft User Experience Virtualization** node *is not* present because you deleted the administrative template for UE-V and then close the Group Policy Management Editor and **GPMC**.
 
 22. On  **LON-CL1**, on the taskbar, select  **File Explorer**, select the  **PolicyDefinitions** thumbnail, and in the address bar, select **Policies**.
 
-23. In the details pane, right-click  **PolicyDefinitions**, select  **Delete**, ** **and then select  **Yes**.
+23. In the details pane, right-click  **PolicyDefinitions**, select  **Delete**, and then select  **Yes**.
 
 24. In the  **GPMC**, in the navigation pane, right-click  **Background1** GPO and then select **Edit**.
 
-25. In Group Policy Management Editor, in the navigation pane, expand  **Policies** under **Computer Configuration**, verify that  **Administrative Template** nodes depict that policy definitions are retrieved again from the local computer.
+25. In Group Policy Management Editor, in the navigation pane, expand  **Policies** under  
+**Computer Configuration**, verify that the **Administrative Template** nodes depict that policy definitions are retrieved again from the **local computer**.
 
-26. In the navigation pane, expand  **Administrative Templates** and verify that **Microsoft Office 2016 (Machine)** node is not present. Expand **Windows Components**, verify that  **Microsoft User Experience Virtualization** node is present and then close Group Policy Management Editor.
+26. In the navigation pane, expand  **Administrative Templates** and verify that the  
+**Microsoft Office 2016 (Machine)** node *is not* present. Expand **Windows Components**, verify that the **Microsoft User Experience Virtualization** node *is* present and then close Group Policy Management Editor.
 
->  **Note:** Updates that you performed in central store are not effective, because local copy of administrative templates is used again.
+    >  **Note:** Updates that you performed in central store are not effective, because local copy of administrative templates is used again.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have configured and linked GPOs, modified the GPO processing order, created a central store, and generated an RSoP report.
 
@@ -230,7 +244,7 @@
 
   - Location:  **Desktop**
 
-  - Target path:  **C:\**
+  - Target path:  **C:\\**
 
 
 5. In the navigation pane, right-click  **Shortcuts**, select  **New** and then select **Shortcut**.
@@ -242,16 +256,16 @@
 
   - Location:  **Desktop**
 
-  - Target path:  **C:\**
+  - Target path:  **C:\\**
 
 
 7. On the  **Common** tab, select **Apply once and do not reapply** check box and then select **OK**.
 
-8. On  **LON-CL2**, where you are signed in as Beth, verify that currently there is only Recycle Bin icon on the desktop.
+8. On  **LON-CL2**, where you are signed in as Beth, verify that currently there is only the Recycle Bin icon on the desktop.
 
 9. On the taskbar, right-click  **Start**, and then select  **Windows PowerShell**.
 
-10. In Windows PowerShell, type  **gpupdate /force**, ** **and then press Enter to refresh the GPOs.
+10. In Windows PowerShell, type  **gpupdate /force**, and then press Enter to refresh the GPOs.
 
 11. Verify that  **Shortcut1** and **Shortcut2** are added to the desktop.
 
@@ -263,21 +277,21 @@
 
 15. On the taskbar, click  **Start**, type  **explorer**, and then select  **Internet Explorer**.
 
-16. In Internet Explorer, press  **Alt**, select  **Tools** and then select **Internet options**. Verify that the  **Home page** text box has a default ** **value, as well as that  **Start with home page** option is selected and then select **OK**.
+16. In Internet Explorer, press  **Alt**, select  **Tools** and then select **Internet options**. Verify that the  **Home page** text box has a default value, as well as that  **Start with home page** option is selected and then select **OK**.
 
 17. On  **LON-CL1**, in Group Policy Management Editor in which Preferences GPO is opened, in the navigation pane, expand  **Control Panel Settings**, right-click  **Internet Settings**, select  **New** and then select **Internet Explorer 10**.
 
-18. In the  **New Internet Explorer 10 Properties** dialog box, in the text box in **Home page** section, type **http://www.microsoft.com/learning**.
+18. In the  **New Internet Explorer 10 Properties** dialog box, in the text box in **Home page** section, type **https://www.microsoft.com/learning**.
 
-19. Note that the text box in  **Home page** section is underlined with dotted red line, which means that setting is not enabled. Press F6 ** **and verify that line color changed to green.
+19. Note that the text box in  **Home page** section is underlined with dotted red line, which means that setting is not enabled. Press **F6** and verify that line color changed to green.
 
 20. In  **Startup** section, select **Start with tabs from the last session** radio button, press **F7** to change line color for this option from green to red, and then select **OK**.
 
-21. On  **LON-CL2**, In Windows PowerShell, type  **gpupdate /force**, ** **and then press Enter to refresh the GPOs.
+21. On  **LON-CL2**, In Windows PowerShell, type  **gpupdate /force**, and then press Enter to refresh the GPOs.
 
-22. In Internet Explorer, press Alt, select  **Tools**, ** **and then select  **Internet options**. Verify that the Home page is now set to  **http://www.microsoft.com/learning**, which you configured in the preference. As preferences are not enforced, you can modify the home page in Internet Explorer. As startup setting is disabled in Group Policy preference, value that you configured in the preference is not applied.
+22. In Internet Explorer, press Alt, select  **Tools**, and then select  **Internet options**. Verify that the Home page is now set to  **https://www.microsoft.com/learning**, which you configured in the preference. As preferences are not enforced, you can modify the home page in Internet Explorer. As startup setting is disabled in Group Policy preference, the value that you configured in the preference is not applied.
 
-23. In  **Internet Options** dialog box, select **Cancel**, ** **and then close Internet Explorer.
+23. In  **Internet Options** dialog box, select **Cancel**, and then close Internet Explorer.
 
 
 
@@ -285,7 +299,7 @@
   
 1. On  **LON-CL2**, on the desktop, right-click  **Shortcut1**, and then select  **Delete**.
 
-2. In Windows PowerShell, type  **gpupdate /force**, ** **and then press Enter to refresh the GPOs.
+2. In Windows PowerShell, type  **gpupdate /force**, and then press Enter to refresh the GPOs.
 
 3. Verify that Shortcut1 reappears. If you delete the shortcut, it will reappear each time that GPOs are refreshed.
 
@@ -293,16 +307,17 @@
 
 5. In Select User, Computer, or Group dialog, in Enter the object name to select text box, type  **beth**, and then select  **OK**.
 
-6. In the details pane, in Security Filtering section, select  **Authenticated Users**, select  **Remove**, ** **select  **OK**, read the dialog, and then select  **OK**. Verify that only Beth Burke is listed in Security Filtering section.
+6. In the details pane, in Security Filtering section, select  **Authenticated Users**, select  **Remove**, select  **OK**, read the dialog, and then select  **OK**. Verify that only Beth Burke is listed in Security Filtering section.
 
-7. On  **LON-CL2**, on the desktop, right-click  **Shortcut1**, ** **and then select  **Delete**.
+7. On  **LON-CL2**, on the desktop, right-click  **Shortcut1**, and then select  **Delete**.
 
-8. In Windows PowerShell, type  **gpupdate /force**, ** **and then press Enter to refresh the GPOs.
+8. In Windows PowerShell, type  **gpupdate /force**, and then press Enter to refresh the GPOs.
 
 >  **Note:** This time Shortcut1 does not reappear. Although Beth was listed in the **Security Filtering** section, GPOs are applied in the computers’ security context. Because **LON-CL2**, the computer on which Beth is signed in, does not have at least Read permissions to the  **Preferences** GPO, it cannot apply the settings from the GPO.
+
 9. On  **LON-CL1**, in the details pane, in  **Security Filtering** section, select **Add**, type  **domain computers**, and then select  **OK**.
 
-10. On  **LON-CL2**, in Windows PowerShell, type  **gpupdate /force**, ** **and then press Enter to refresh the GPOs. This time  **Shortcut1** reappears, because **LON-CL2** is a member of the **Domain Computers** group and it has permission to read the **Preferences** GPO.
+10. On  **LON-CL2**, in Windows PowerShell, type  **gpupdate /force**, and then press Enter to refresh the GPOs. This time  **Shortcut1** reappears, because **LON-CL2** is a member of the **Domain Computers** group and it has permission to read the **Preferences** GPO.
 
 11. On  **LON-CL1**, in Group Policy Management Editor, in the navigation pane, select  **Shortcuts**.
 
@@ -314,11 +329,13 @@
 
 15. Click  **New Item** and then select **File Match**.
 
-16. In  **Targeting Editor**, in lower pane, in  **Mach type** drop down list, select **Folder exists** and in **Path** text box type **C:\Folder1**.
->  **Note:** Filter condition should read: free disk space is greater than or equal to 90 GB on the system drive AND the folder **C:\Folder1** exists.
+16. In  **Targeting Editor**, in lower pane, in  **Mach type** drop down list, select **Folder exists** and in **Path** text box type **C:\\Folder1**.
+
+>  **Note:** Filter condition should read: free disk space is greater than or equal to **90 GB** on the system drive **AND** the folder **C:\\Folder1** exists.
+
 17. In Targeting Editor, select  **OK**, in the  **Shortcut1 Properties** dialog box, select **OK** and then close Group Policy Management Editor.
 
-18. On  **LON-CL2**, in Windows PowerShell, type the following command to create large file, and then press Enter (number 6 is followed by 10 zeroes): 
+18. On  **LON-CL2**, in Windows PowerShell, type the following command to create large file, and then press Enter (the number 6 is followed by 10 zeroes): 
 
   ```
   Fsutil file createnew file1.txt 60000000000
@@ -326,30 +343,34 @@
 
 19. On the taskbar, select  **File Explorer**.
 
-20. In File Explorer, in the navigation pane, right-click  **Local Disk (C:)**, select  **Properties**, view Free space, and then select  **OK**. Disk C has less than 90 GB free space.
+20. In File Explorer, in the navigation pane, right-click  **Local Disk (C:)**, select  **Properties**, view Free space, and then select  **OK**. Disk C: has less than 90 GB free space.
 
-21. On the desktop, right-click  **Shortcut1**, ** **and then select  **Delete**.
+21. On the desktop, right-click  **Shortcut1**, and then select  **Delete**.
 
-22. In Windows PowerShell, type  **gpupdate /force**, ** **and then press Enter to refresh the GPOs.
->  **Note:** **Shortcut1** does not appear, as disk has less than 90GB free space and folder **C:\Folder1** does not exist.
-23. In File Explorer, in the navigation pane, select  **Local Disk (C:)**. In the details pane, right-click empty space, select  **New**, ** **select  **Folder**, type  **Folder1**, ** **and then press Enter. 
+22. In Windows PowerShell, type  **gpupdate /force**, and then press Enter to refresh the GPOs.
+
+>  **Note:** **Shortcut1** *does not* appear, as the disk has *less than* **90GB** free space and the folder **C:\\Folder1** *does not* exist.
+
+23. In File Explorer, in the navigation pane, select  **Local Disk (C:)**. In the details pane, right-click empty space, select  **New**, select  **Folder**, type  **Folder1**, and then press Enter. 
 
 24. In Windows PowerShell, type  **gpupdate /force**, and then press Enter to refresh the GPOs.
->  **Note:** Shortcut1 does not appear. Although **C:\Folder1** now exists, disk has still less than 90GB free space.
+
+>  **Note:** **Shortcut1** *does not* appear. Although **C:\\Folder1** now *exists*, the disk still has *less than* **90GB** free space.
+
 25. In Windows PowerShell, type  **del file1.txt**, and then press Enter.
 
-26. In File Explorer, in the navigation pane, right-click  **Local Disk (C:)**, select  **Properties**, view Free space, and then select  **OK**. Disk C has now more than 90 GB free space.
+26. In File Explorer, in the navigation pane, right-click  **Local Disk (C:)**, select  **Properties**, view Free space, and then select  **OK**. Disk C: now has *more than* **90 GB** free space.
 
 27. In Windows PowerShell, type  **gpupdate /force**, and then press Enter to refresh the GPOs.
 
->  **Note:** Both conditions from item-level targeting are met and Shortcut1 now appears on the desktop.
+>  **Note:** *Both* conditions from item-level targeting *are met* and **Shortcut1** now appears on the desktop.
 
 
 #### Task 3: Prepare for the next module
   
  When you are finished with the lab, revert  **LON-CL1** and **LON-CL2** virtual machines to their initial state:
 
-1. On  **LON-DC1**, where you are signed in as Adatum\Administrator, on the taskbar, select  **File Explorer**.
+1. On  **LON-DC1**, where you are signed in as Adatum\\Administrator, on the taskbar, select  **File Explorer**.
 
 2. In File Explorer, in the navigation pane, expand  **This PC**, expand  **Allfiles (E:)**, expand  **Labfiles**, and then select  **Mod05**.
 
@@ -363,7 +384,10 @@
 
 7. Repeat steps 5 and 6 for  **20697-2C-LON-CL2**.
 
->  **Note:** Do not revert **LON-DC1**.  **LON-DC1** is synchronizing on-premises AD DS with Azure AD. You can shut down **LON-DC1**.
+    >  **Note:** **_Do not revert LON-DC1!_**  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.  
+ (You can shut down **LON-DC1**.)
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you will configure and apply Group Policy preferences. You will also configure and test GPO filtering and item-level targeting.
 

--- a/Instructions/206972C_LAB_AK_06.md
+++ b/Instructions/206972C_LAB_AK_06.md
@@ -1,4 +1,4 @@
-# Lab Answer Key:  Module 6: Managing devices in Microsoft Office 365
+﻿# Lab Answer Key:  Module 6: Managing devices in Microsoft Office 365
 # Lab A: Managing devices in Office 365 (Part 1)
   
 ## Exercise 1: Obtaining an Office 365 subscription
@@ -7,16 +7,15 @@
   
 1. On  **LON-CL3**, open Microsoft Edge.
 
-2. In the address bar, type  **https://portal.office.com/AdminPortal**, and then press Enter. 
+2. In the address bar, type  [**https://portal.office.com/AdminPortal**](https://portal.office.com/AdminPortal), and then press Enter. 
 
 3. Sign in with the following account:
 
-
-- Username:  **GAdmin@&lt;initials&gt;MMDDYY.onmicrosoft.com**
+- Username:  **GAdmin@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password: The password you created in Module 3
 
->  **Note:** The following prompts might vary as the portal undergoes regular development.
+    >  **Note:** The following prompts might vary as the portal undergoes regular development.
 
 4. If prompted, on the  **Don't lose access to your account** page, select **Set it up now**.
 
@@ -24,7 +23,7 @@
 
 6. If necessary, close any welcome messages that appear.
 
-7. In the  **Office 365 Admincenter**, in the navigation pane, select  **Billing** and then select ** Subscriptions**. 
+7. In the  **Office 365 Admincenter**, in the navigation pane, select  **Billing** and then select **Subscriptions**. 
 
 8. In the details pane, select  **Add subscriptions**. 
 
@@ -32,11 +31,11 @@
 
 10. On the  **confirm your order** webpage, select **Try now**.
 
->  **Note:** If you receive an error saying that verification checks on your payment method have failed, try again in a few minutes.
+    >  **Note:** If you receive an error saying that verification checks on your payment method have failed, try again in a few minutes.
 
 11. On the  **order receipt** webpage, select **continue**.
 
-12. On the  **Admin center** webpage, in the navigation pane, select **Billing** and then select ** Subscriptions**. You can now see the Office 365 Enterprise E3 Trial subscription listed.
+12. On the  **Admin center** webpage, in the navigation pane, select **Billing** and then select **Subscriptions**. You can now see the Office 365 Enterprise E3 Trial subscription listed.
 
 13.  Leave the portal open.
 
@@ -50,14 +49,13 @@
 
 3. In the  **Adam Hobbs** window, next to Product licenses, select **Edit**.
 
-4. Next to Office 365 Enterprise E3, select  **Off** to enable the license.
+4. Next to Office 365 Enterprise E3, click the **Off** switch to **enable** the license.
 
 5. Set the location to  **United States**, and then select  **Save**.
 
 6. Select  **Close** twice.
 
 7. Repeat steps 2 through 6 for the following users:
-
 
 - Abbi Skinner
 
@@ -66,7 +64,8 @@
 - GAdmin
 
 
->  **Result**: After completing this exercise, you should have successfully obtained a trial subscription to Microsoft Office 365.
+    >  **Result**: After completing this exercise, you should have successfully obtained a trial subscription to Microsoft Office 365.
+
 
 
 ## Exercise 2: Enabling MDM
@@ -81,7 +80,9 @@
 
 4. On the  **Need one thing from you before we set everything up…** page, accept the default security group and then select **Start setup**. 
 
->  **Note:** The initialization process can take considerable time to complete.
+    >  **Note:** The initialization process can take considerable time to complete.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have successfully enabled MDM in Office 365.
 
@@ -90,7 +91,7 @@
   
 #### Task 1: Create a DLP
   
-1. On  **LON-CL3**, in Microsoft Edge, open the Security &amp; Compliance center if it is not already open.
+1. On  **LON-CL3**, in Microsoft Edge, open the **Security &amp; Compliance center** if it is not already open.
 
 2. Expand  **Data loss prevention** and select **Policy**.
 
@@ -100,7 +101,8 @@
 
 5. In the  **Name** text box, type **Block external sharing of PII**, and then select  **Next**.
 
-6. On the  **Choose locations** page, verify that **All locations in Office 365. Includes content in Exchange email and OneDrive and SharePoint documents** is selected, and then select **Next**.
+6. On the  **Choose locations** page, verify that:  
+**All locations in Office 365. Includes content in Exchange email and OneDrive and SharePoint documents** is selected, and then select **Next**.
 
 7. Select  **Edit**.
 
@@ -109,7 +111,6 @@
 9. Select  **Add**.
 
 10. Select the following  **Sensitive information types**:
-
 
 - U.S. / U.K. Passport Number
 
@@ -120,39 +121,41 @@
 - U.S. Social Security Number (SSN)
 
 
-1. Select  **Add**, and then select  **Done**.
+11. Select  **Add**, and then select  **Done**.
 
-2. Select  **Save**.
+12. Select  **Save**.
 
-3. Verify  **Detect when this content is shared: with people outside my organization** is selected, and then select **Next**.
+13. Verify  **Detect when this content is shared: with people outside my organization** is selected, and then select **Next**.
 
-4. Under  **Restrict who can access the content and override the policy**, select  **Customize access and override permissions**.
+14. Under  **Restrict who can access the content and override the policy**, select:  
+**Customize access and override permissions**.
 
-5. Select  **Require a business justification to override** and **Override the rule automatically if they report it as a false positive,** and then select **Save**.
+15. Select  **Require a business justification to override** and  
+**Override the rule automatically if they report it as a false positive,** and then select **Save**.
 
-6. Select  **Next**.
+16. Select  **Next**.
 
-7. Select  **Yes, turn it on right away**, and select  **Next**.
+17. Select  **Yes, turn it on right away**, and select  **Next**.
 
-8. On the  **Review your settings** page, select **Create**.
+18. On the  **Review your settings** page, select **Create**.
 
-9. Select  **Close**.
+19. Select  **Close**.
 
-10. On the  **Data loss prevention** page, select the **Block external sharing of PII** policy.
+20. On the  **Data loss prevention** page, select the **Block external sharing of PII** policy.
 
-11. Select  **Policy settings**.
+21. Select  **Policy settings**.
 
-12. Turn off the  **Low volume of content detected Block external sharing of PII** rule.
+22. Turn off the  **Low volume of content detected Block external sharing of PII** rule.
 
-13. Expand the  **High volume of content detected Block external sharing of PII** rule.
+23. Expand the  **High volume of content detected Block external sharing of PII** rule.
 
-14. Select  **Edit rule**.
+24. Select  **Edit rule**.
 
-15. Next to  **U.S. Social Security Number (SSN)**, change the  **Instance count min** value to **1**.
+25. Next to  **U.S. Social Security Number (SSN)**, change the  **Instance count min** value to **1**.
 
-16. Repeat the values for the other  **Sensitive information type**.
+26. Repeat the values for the other  **Sensitive information type**.
 
-17. Select  **Save**, and then select  **Save** again.
+27. Select  **Save**, and then select  **Save** again.
 
 
 
@@ -162,7 +165,7 @@
 
 2. Select  **Upload**, and then select  **Files**.
 
-3. Navigate to  **E:\Labfiles\Mod06\**, and then select  **EmployeeTravel.xlsx**.
+3. Navigate to  **E:\\Labfiles\\Mod06\\**, and then select  **EmployeeTravel.xlsx**.
 
 4. Select  **Open**.
 
@@ -173,8 +176,11 @@
 7. In the  **Link Settings** drop-down, select **Specific people**, and then select  **Apply**.
 
 8. In the  **Enter a name or email address** box, type **mary@fabrikam.com**, and then press  **Enter**.
->  **Note:** You should see the message “This item contains sensitive information. It can’t be shared with people outside your organization.”
-> If you do not see this message, wait before continuing. It may take up to an hour or more for the policy to be applied.
+
+    >  **Note:** You should see the message:  
+**"This item contains sensitive information. It can’t be shared with people outside your organization."**  
+If you do not see this message, wait before continuing. It may take up to an hour or more for the policy to be applied.
+
 9. Select  **View policytip**, and then select  **Override**.
 
 10. In the text box, enter the text  **Sharing employee information with company travel agent**, and then select  **Submit.**
@@ -187,18 +193,20 @@
 
 #### Task 3: View alerts in the Security &amp; Compliance center
   
-1. On  **LON-CL3**, in Microsoft Edge, open  **https://protection.office.com**.
+1. On  **LON-CL3**, in Microsoft Edge, open  [**https://protection.office.com**](https://protection.office.com).
 
 2. Expand  **Data loss prevention**, and then select  **Policy**.
 
 3. View the  **DLP policy matches** report.
 
 4. View the  **DLP false positives and overrides** report.
->  **Note:** You should see an entry for the file that you uploaded in both reports, because you chose to override the policy that it matched.
-> It can take several hours for this report to be updated.
+
+    >  **Note:** You should see an entry for the file that you uploaded in both reports, because you chose to override the policy that it matched.  
+  It can take several hours for this report to be updated.
+
 5. Expand  **Reports**, and then select  **Dashboard**.
 
->  **Note:** You should see data in each report, because the file that you uploaded matched a DLP policy.
+    >  **Note:** You should see data in each report, because the file that you uploaded matched a DLP policy.
 
 
 #### Task 4: Prepare for the next lab
@@ -216,7 +224,7 @@
   
 #### Task 1: Create a security group
   
-1. On LON-CL3, switch to the  **Office 365 Admincenter**. 
+1. On LON-CL3, switch to the  **Office 365 Admin center**. 
 
 2. In the navigation pane, select  **Groups**, and then select  **Groups**.
 
@@ -240,7 +248,7 @@
 
 #### Task 2: Create an MDM policy
   
-1. Open the Security &amp; Compliance center, in the navigation pane, expand  **Data loss prevention**, and then select  **Device security policies**. 
+1. Open the **Security &amp; Compliance center**, in the navigation pane, expand  **Data loss prevention**, and then select  **Device security policies**. 
 
 2. Select  **Create a policy**.
 
@@ -250,31 +258,29 @@
 
 5. On the  **What requirements do you want to have on devices?** page, configure the following settings, and then select **Next**: 
 
+-  Require a password: **Yes**
 
--  **Require a password: Yes**
-
--  **Minimum password length: 4**
+-  Minimum password length: **4**
 
 -  **Block access and report violation**
 
 
-1. On the  **What else do you want to configure?** page, enable the following settings, and then select **Next**:
+6. On the  **What else do you want to configure?** page, enable the following settings, and then select **Next**:
 
 
 -  **Block screen capture**
 
 -  **Block connection with removable storage**
 
+-  **Block Bluetooth connection**
 
-1.  **Block Bluetooth connection**
+7. On the  **Do you want to apply this policy now?** page, select **Yes**.
 
-2. On the  **Do you want to apply this policy now?** page, select **Yes**.
+8. On the  **Do you want to apply this policy now?** page, select **Add**.
 
-3. On the  **Do you want to apply this policy now?** page, select **Add**.
+9. From the  **Groups** list, select the group with the **Display Name** of **Windows Devices**, and then select  **Add**.
 
-4. From the  **Groups** list, select the group with the **Display Name** of **Windows Devices**, and then select  **Add**.
-
-5. Select  **Next**, and then select ** Create this policy**.
+10. Select  **Next**, and then select **Create this policy**.
 
 
 
@@ -288,7 +294,7 @@
 
 4. Select  **Connect**.
 
-5. On the  **Set up a work or schoolaccount** page, in the **Email address** box, type **Abbi@your_domain.onmicrosoft.com**, and then select  **Next**.
+5. On the  **Set up a work or school account** page, in the **Email address** box, type **Abbi@*&lt;your_domain&gt;*.onmicrosoft.com**, and then select  **Next**.
 
 6. On the  **Enter password** page, in the **Password** box, type **Pa55w.rd**, and then select  **Sign in**.
 
@@ -300,7 +306,7 @@
 
 10. On the  **Choose an account** page, select **Exchange**. 
 
-11. On the  **Exchange** page, in the **Email address** box, type **Abbi@your_domain.onmicrosoft.com**, and then select  **Next**.
+11. On the  **Exchange** page, in the **Email address** box, type **Abbi@*&lt;your_domain&gt;*.onmicrosoft.com**, and then select  **Next**.
 
 12. On the  **Let’s get you signed in** page, select your Abbi account and click **Continue**.
 
@@ -308,15 +314,18 @@
 
 14. On the  **Accounts** page, select **Go to Inbox**.
 
->  **Note:** Wait a few minutes to give the policy time to apply to your device.
+    >  **Note:** Wait a few minutes to give the policy time to apply to your device.
+
 
 
 #### Task 4: View managed devices
   
-1. On  **LON-CL3**, in Microsoft Edge, switch to the Security &amp; Compliance center, expand  **Data loss prevention**, and then select  **Device management**.
+1. On  **LON-CL3**, in Microsoft Edge, switch to the **Security &amp; Compliance center**, expand  **Data loss prevention**, and then select  **Device management**.
 
 2. In the  **Select a view** list, select **Blocked**. Check if any devices are blocked. 
->  **Note:** There may be no blocked devices listed.
+
+    >  **Note:** There may be no blocked devices listed.
+
 3. In the  **Select a view** list, select **All**.
 
 4. View the list of managed devices. 
@@ -335,10 +344,15 @@
 
 4. Repeat steps 2 and 3 for  **20697-2C-LON-CL4**.
 
->  **Note:** Do not revert **LON-DC1**.  **LON-DC1** is synchronizing on-premises AD DS with Azure AD. You can shut down LON-DC1 and MT17B-WS2016-NAT.
+    >  **Note:** **_Do not revert LON-DC1!_**  **LON-DC1** is synchronizing on-premises AD DS with Azure AD.  
+ (You can shut down **LON-DC1** and **MT17B-WS2016-NAT**.)
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have successfully enrolled devices and ensured that they comply with corporate policies for Office 365 access.
 
+
+##
 
 
 ©2016 Microsoft Corporation. All rights reserved.

--- a/Instructions/206972C_LAB_AK_07.md
+++ b/Instructions/206972C_LAB_AK_07.md
@@ -1,40 +1,37 @@
-# Lab Answer Key:  Module 7: Managing devices by using Microsoft Intune
+﻿# Lab Answer Key:  Module 7: Managing devices by using Microsoft Intune
 # Lab A: Implementing Intune
   
 ## Exercise 1: Adding Intune users
   
 #### Task 1: Assign Microsoft Enterprise Mobility + Security licenses to users
   
-1. On  **LON-CL3**, open Microsoft Edge and navigate to https://portal.office.com/AdminPortal.
+1. On  **LON-CL3**, open Microsoft Edge and navigate to [**https://portal.office.com/AdminPortal**](https://portal.office.com/AdminPortal).
 
 2. Sign in with the following account:
 
-
-- Username: GAdmin@ _initialsMMDDYY_.onmicrosoft.com
+- Username: **GAdmin@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password: The password you created in Module 3
 
+3. In the Navigation pane, expand  **Users** and then select **Active Users**.
 
-1. In the Navigation pane, expand  **Users** and then select **Active Users**.
+4. In the user list, select  **Adam Hobbs**.
 
-2. In the user list, select  **Adam Hobbs**.
+5. In the  **Adam Hobbs** window, next to **Product licenses**, select  **Edit**.
 
-3. In the  **Adam Hobbs** window, next to **Product licenses**, select  **Edit**.
+6. To **enable** the license, next to  **Enterprise Mobility + Security E5**, select the **Off** switch. 
 
-4. To enable the license, next to  **Enterprise Mobility + Security E5**, select  **Off**. 
+7. If necessary, set the location to  **United States**, and then select  **Save**.
 
-5. If necessary, set the location to  **United States**, and then select  **Save**.
+8. Select  **Close** twice.
 
-6. Select  **Close** twice.
+9. Repeat steps 4 through 7 for the following users:
 
-7. Repeat steps 4 through 7 for the following users:
+- **Abbi Skinner**
 
+- **Ada Russell**
 
-- Abbi Skinner
-
-- Ada Russell
-
-- Aidan Norman
+- **Aidan Norman**
 
 
 
@@ -56,65 +53,61 @@
 
 #### Task 3: Verify user access
   
-1. On  **LON-CL4**, open Microsoft Edge and navigate to https://portal.office.com.
+1. On  **LON-CL4**, open Microsoft Edge and navigate to [**https://portal.office.com**](https://portal.office.com).
 
 2. Sign in with the following account:
 
-
-- Username:  **Abbi@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Abbi@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
->  **Note:** Notice that Abbi Skinner does not have access to the Admin console.
+    >  **Note:** Notice that Abbi Skinner does not have access to the Admin console.
 
   **Open the Intune Company Portal**
 
-1. Use Microsoft Edge to navigate to https://portal.manage.microsoft.com.
+3. Use Microsoft Edge to navigate to [**https://portal.manage.microsoft.com**](https://portal.manage.microsoft.com).
 
-2. Sign in with the following account:
+4. Sign in with the following account:
 
-
-- Username:  **Abbi@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Abbi@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
->  **Note:** Abbi Skinner should have access to the Company Portal website. No devices are yet configured.
+    >  **Note:** Abbi Skinner should have access to the Company Portal website. No devices are yet configured.
 
-1. Close Microsoft Edge.
+5. Close Microsoft Edge.
 
 
 
 #### Task 4: Verify administrator access
   
-1. On  **LON-CL4**, use Microsoft Edge to navigate to https://portal.office.com/AdminPortal.
+1. On  **LON-CL4**, use Microsoft Edge to navigate to [**https://portal.office.com/AdminPortal**](https://portal.office.com/AdminPortal).
 
 2. Sign in with the following account:
 
-
-- Username:  **Adam@initialsMMDDYY.onmicrosoft.com**
-
-- Password:  **Pa55w.rd**
-
-
-1. Under  **Admin centers**, select I **ntune**.
-
->  **Note:** The **Intune console** in the Azure portal attempts to open. Adam Hobbs should have access.
-
-  ** Open the Intune classic portal**
-
-1. Open Internet Explorer and navigate to https://admin.manage.microsoft.com.
-
-2. Sign in with the following account:
-
-
-- Username:  **Adam@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Adam@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
->  **Note:** If prompted, install Silverlight with default settings.
+3. Under  **Admin centers**, select I **ntune**.
+
+    >  **Note:** The **Intune console** in the Azure portal attempts to open. Adam Hobbs should have access.
+
+
+   **Open the Intune classic portal**
+
+4. Open Internet Explorer and navigate to [**https://admin.manage.microsoft.com**](https://admin.manage.microsoft.com).
+
+5. Sign in with the following account:
+
+- Username:  **Adam@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
+
+- Password:  **Pa55w.rd**
+
+    >  **Note:** If prompted, install Silverlight with default settings.  
 >  **Note:** Adam Hobbs should have access to the Intune classic portal website.
 
-1. Close Internet Explorer and Microsoft Edge.
+6. Close Internet Explorer and Microsoft Edge.
 
 
 >  **Result**: After completing this exercise, you should have assigned Intune licenses to users, assigned Global Administrator access to a user, verified that users can access the Company Portal, and verified that the Global Administrator can manage Intune from both the Azure portal and the Intune classic portal.
@@ -124,31 +117,29 @@
   
 #### Task 1: Create an Azure AD group to manage role membership
   
-1. On  **LON-CL3**, open Microsoft Edge to navigate to https://portal.azure.com.
+1. On  **LON-CL3**, open Microsoft Edge to navigate to [**https://portal.azure.com**](https://portal.azure.com).
 
 2. Sign in with the following account:
 
-
-- Username:  **GAdmin @initialsMMDDYY.onmicrosoft.com**
+- Username:  **GAdmin@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password: The password you created in Module 3
 
+3. In the Navigation pane, select  **Azure Active Directory**.
 
-1. In the Navigation pane, select  **Azure Active Directory**.
+4. Select  **Users and groups**, and then select  **All groups**. 
 
-2. Select  **Users and groups**, and then select  **All groups**. 
+5. Select  **New group**.
 
-3. Select  **New group**.
+6. Enter  **Adatum Custom Role Test** in the **Name** box.
 
-4. Enter  **Adatum Custom Role Test** in the **Name** box.
+7. Under Membership type, select  **Assigned**, and then select  **Members**.
 
-5. Under Membership type, select  **Assigned**, and then select  **Members**.
+8. In the  **Select** box, enter **Allan**.
 
-6. In the  **Select** box, enter **Allan**.
+9. Select  **Allan Yoo**, and then select  **Select.**
 
-7. Select  **Allan Yoo**, ** **and then select ** Select.**
-
-8. Select  **Create** and then close the **Group** pane **.**
+10. Select  **Create** and then close the **Group** pane **.**
 
 
 
@@ -166,13 +157,13 @@
 
 6. Next to  **Assign**, select  **Yes**.
 
-7. Next to  **Read**, select  **Yes**, ** **and then select  **OK** twice.
+7. Next to  **Read**, select  **Yes**, and then select  **OK** twice.
 
 8. Select  **Create**.
 
 9. Select the role  **Adatum Intune Test**.
 
-10. Select  **Assignments**, ** **and then select  **Assign**.
+10. Select  **Assignments**, and then select  **Assign**.
 
 11. In the  **Assignmentname** box, enter **Test assignment**.
 
@@ -195,7 +186,7 @@
 
 Sign in with the following account:
 
-- Username:  **Allan @initialsMMDDYY.onmicrosoft.com**
+- Username:  **Allan@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
@@ -223,7 +214,7 @@ You should be able to view the  **Device compliance** blade.
 2. Sign in with the following account:
 
 
-- Username:  **GAdmin@initialsMMDDYY.onmicrosoft.com**
+- Username:  **GAdmin@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password: The password you created in Module 3
 
@@ -244,7 +235,8 @@ You should be able to view the  **Device compliance** blade.
 
 10. On the  **Devices** page, select **Azure AD devices**.
 
-11. Next to  **LON-CL3**, at the end of the row, click the three dots (…) and then click  **Delete**. Click  **Yes** when prompted.
+11. Next to  **LON-CL3**, at the end of the row, click the three dots (**…**) and then click  **Delete**.  
+Click  **Yes** when prompted.
 
 12. Repeat step 11 for  **LON-CL4**.
 
@@ -256,12 +248,12 @@ You should be able to view the  **Device compliance** blade.
 
 2. Select  **Accounts**.
 
-3. Select  **Access work or school**, ** **and then select  **Connect.**
+3. Select  **Access work or school**, and then select  **Connect.**
 
 4.  Sign in with the following account:
 
 
-- Username:  **Abbi@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Abbi@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
@@ -290,7 +282,7 @@ You should be able to view the  **Device compliance** blade.
 
 2. Select  **Users and groups**, and then select  **All groups**.
 
-3. Select  **New group**, ** **and then in the  **Name** box, enter **Windows Devices Dynamic**.
+3. Select  **New group**, and then in the  **Name** box, enter **Windows Devices Dynamic**.
 
 4. In the  **Membership type** list, select **Dynamic Device**.
 
@@ -306,7 +298,7 @@ You should be able to view the  **Device compliance** blade.
 
 10. Select the  **Windows DevicesDynamic** group.
 
-11. Select  **Members**, ** **and then verify that  **LON-CL3** is listed.
+11. Select  **Members**, and then verify that  **LON-CL3** is listed.
 
 12. Close Microsoft Edge.
 
@@ -318,17 +310,18 @@ You should be able to view the  **Device compliance** blade.
   
 #### Task 1: Verify that the Intune classic portal does not open in Microsoft Edge
   
-1. On  **LON-CL3**, open the Microsoft Edge browser, attempt to navigate to https://admin.manage.microsoft.com.
+1. On  **LON-CL3**, open the Microsoft Edge browser, attempt to navigate to [**https://admin.manage.microsoft.com**](https://admin.manage.microsoft.com).
 
 2. Sign in with the following account:
 
 
-- Username:  **GAdmin@initialsMMDDYY.onmicrosoft.com**
+- Username:  **GAdmin@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password: The password you created in Module 3
 
 
-3. Verify that you see the message “Unsupported browser or browser mode.”
+3. Verify that you see the message  
+**"Unsupported browser or browser mode."**
 
 4. Close Microsoft Edge.
 
@@ -336,12 +329,12 @@ You should be able to view the  **Device compliance** blade.
 
 #### Task 2: Verify that accessing the Intune classic portal from Internet Explorer requires Silverlight
   
-1. On  **LON-CL3**, open Internet Explorer, attempt to navigate to https://admin.manage.microsoft.com.
+1. On  **LON-CL3**, open Internet Explorer, attempt to navigate to [**https://admin.manage.microsoft.com**](https://admin.manage.microsoft.com).
 
 2. Sign in with the following account:
 
 
-- Username:  **Adam@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Adam@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
@@ -360,7 +353,8 @@ You should be able to view the  **Device compliance** blade.
 
 2. Verify you can view  **LON-CL3** in the list of devices
 
-3. Select  **Groups**, ** **and then verify that you see the message “Intune groups are now managed as groups in Azure Active Directory!”
+3. Select  **Groups**, and then verify that you see the message  
+**"Intune groups are now managed as groups in Azure Active Directory!"**
 
 4. Close Internet Explorer.
 
@@ -386,7 +380,7 @@ You should be able to view the  **Device compliance** blade.
 2. Sign in with the following account: 
 
 
-- Username:  **Adam@initialsMMDDYY.onmicrosoft.com**
+- Username:  **Adam@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
 - Password:  **Pa55w.rd**
 
@@ -419,17 +413,17 @@ You should be able to view the  **Device compliance** blade.
   - Default server:  **True**
 
 
-13. Next to  **Connection type**, ** **select ** F5 Edge Client**. 
+13. Next to  **Connection type**, select  **F5 Edge Client**. 
 
-14. For the authentication model, select ** Username and password**. 
+14. For the authentication model, select  **Username and password**. 
 
 15. In the  **Custom XML** box, enter the following code:
 
   ```
-  &lt;f5-vpn-conf&gt;&lt;single-sign-on-credential /&gt;&lt;/f5-vpn-conf&gt;
+  <f5-vpn-conf><single-sign-on-credential /></f5-vpn-conf>
   ```
 
-16. Select ** OK** twice, and then select **Create**. 
+16. Select  **OK** twice, and then select **Create**. 
 
 
 
@@ -451,7 +445,7 @@ You should be able to view the  **Device compliance** blade.
   
 1. On  **LON-CL3**, in the Azure portal, select  **Microsoft Intune**.
 
-2. Select  **Devices**, ** **and then select  **All devices**.
+2. Select  **Devices**, and then select  **All devices**.
 
 3. Select  **LON-CL3**, and then select  **Sync**.
 
@@ -459,7 +453,7 @@ You should be able to view the  **Device compliance** blade.
 
 5. Right-click  **Start**, and then select  **Network connections**.
 
-6. Select  **VPN**, ** **and then verify that  **Adatum VPN** appears in **VPN** list.
+6. Select  **VPN**, and then verify that  **Adatum VPN** appears in **VPN** list.
 
 
 >  **Result**: After completing this exercise, you should have created a VPN device profile, deployed the device profile to a group of devices, and verified that the profile was successfully deployed.
@@ -509,31 +503,29 @@ You should be able to view the  **Device compliance** blade.
 
 7. Select  **Select**, and then in the  **Search Applications** box, enter **Exchange**.
 
-8. Select  **Office 365 Exchange Online**, ** **and then select  **Select**.
+8. Select  **Office 365 Exchange Online**, and then select  **Select**.
 
-9. Select  **Done**, and then under  **Access controls**, ** **select  **Grant**.
+9. Select  **Done**, and then under  **Access controls**, select  **Grant**.
 
 10. Select  **Block access**, and then select  **Select.**
 
-11. Under  **Enable policy**, select  **On**, ** **and then select  **Create**.
+11. Under  **Enable policy**, select  **On**, and then select  **Create**.
 
 
 
 #### Task 3: Verify that the conditional access policy is working
   
-1. On  **LON-CL3**, open a new Microsoft Edge tab, then and open http://office.com.
+1. On  **LON-CL3**, open a new Microsoft Edge tab, then and open [**https://office.com**](https://office.com).
 
 2. Attempt to sign in with the following account:
 
-
-  - Username:  **Ada@initialsMMDDYY.onmicrosoft.com**
+  - Username:  **Ada@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
   - Password:  **Pa55w.rd**
 
+3. Verify that you receive the message **"You don’t have access to this."**
 
-3. Verify that you receive the message “You don’t have access to this.”
-
-4. Select  **More details**. You should see the message “Triggered by conditional access”.
+4. Select  **More details**. You should see the message **"Triggered by conditional access"**.
 
 5. Switch back to the  **Microsoft Azure** page and select the **Exchange Online conditional access** policy.
 
@@ -541,7 +533,7 @@ You should be able to view the  **Device compliance** blade.
 
 7. Click  **Save**.
 
-8. Switch back to the Office **.**com web site. Refresh until you can sign in successfully.
+8. Switch back to the **Office.com** web site. Refresh until you can sign in successfully.
 
 9. Close Microsoft Edge.
 
@@ -549,21 +541,20 @@ You should be able to view the  **Device compliance** blade.
 >  **Result**: After completing this exercise, you should have created and deployed a compliance policy, created a conditional access policy for Exchange Online, and verified that the conditional access policy is working.
 
 
+
 ## Exercise 3: Configuring software updates
   
 #### Task 1: Create and assign a Windows 10 update ring
   
-1. On  **LON-CL3**, open Microsoft Edge, and navigate to http://portal.azure.com. 
+1. On  **LON-CL3**, open Microsoft Edge, and navigate to [**https://portal.azure.com**](https://portal.azure.com). 
 
 2. Sign in with the following account: 
 
-
-  - Username:  **Adam@initialsMMDDYY.onmicrosoft.com**
+  - Username:  **Adam@*&lt;initials&gt;&lt;MMDDYY&gt;*.onmicrosoft.com**
 
   - Password:  **Pa55w.rd**
 
-
-3. Click  **More services**.
+3. Click  **All services**.
 
 4. In the  **Search** box enter **Intune**, and then in the results, select  **Intune**.
 
@@ -598,6 +589,8 @@ You should be able to view the  **Device compliance** blade.
 
 >  **Result**: After completing this exercise, you should have created a Windows 10 update ring and assigned devices to it.
 
+
+##
 
 
 ©2016 Microsoft Corporation. All rights reserved.

--- a/Instructions/206972C_LAB_AK_08.md
+++ b/Instructions/206972C_LAB_AK_08.md
@@ -1,4 +1,4 @@
-# Lab Answer Key:  Module 8: Configuring and using Microsoft Store for Business
+﻿# Lab Answer Key:  Module 8: Configuring and using Microsoft Store for Business
 # Lab: Deploying apps and Windows 10 by using Microsoft Store for Business
   
 ## Exercise 1: Signing up and managing Microsoft Store for Business
@@ -7,29 +7,38 @@
   
 1. On  **LON-CL2**, select  **Microsoft Edge** on the taskbar.
 
-2. In Microsoft Edge, type  **https://www.microsoft.com/business-store** in the address bar, and then press Enter.
+2. In Microsoft Edge, type  [**https://www.microsoft.com/business-store**](https://www.microsoft.com/business-store) in the address bar, and then press Enter.
 
 3. In the top-right corner of Microsoft Edge, select the  **Sign in** link.
->  **Note:** The page localizes based on your location.
-4. In the  **Sign in toMicrosoft Store** dialog box, in the **someone@example.com** text box, type **GAdmin@YourInitialsMMDDYYoutlook.onmicrosoft.com**, select  **Next**, ** **in the  **Password** text box, type the password that you have configured for this user in module 3, ** **and then select ** Sign in**.
->  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the _YourInitials-MMDDYY_@outlook.com format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF-121817@outlook.com. In this case, you should sign in as  **GAdmin@DF121817outlook.onmicrosoft.com**.
+
+    >  **Note:** The page localizes based on your location.
+
+4. In the  **Sign in toMicrosoft Store** dialog box, in the **someone@example.com** text box, type **GAdmin@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**, select  **Next**, in the  **Password** text box, type the password that you have configured for this user in module 3, and then select **Sign in**.
+
+    >  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the **_&lt;YourInitials&gt;&lt;MMDDYY&gt;_@outlook.com** format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF121817@outlook.com. In this case, you should sign in as  **GAdmin@DF121817outlook.onmicrosoft.com**.
+
 5. At the bottom of the  **Microsoft Store for Business and Education Services Agreement** page, select both check boxes, and then select **Accept**.
->  **Note:** The page localizes based on your location.
+
+    >  **Note:** The page localizes based on your location.
+
 6. On the  **Microsoft Store for Business** page, select **Manage**.
 
 7. In the navigation pane, select  **Products &amp; services**. In the details pane, verify that the  **Sway**,  **OneNote**,  **PowerPoint Mobile**,  **Excel Mobile**, and  **Word Mobile** apps show a status of **Adding to private store**.
->  **Note:** When you sign up for Microsoft Store for Business, the portal automatically adds Microsoft Sway, Microsoft OneNote, Microsoft PowerPoint Mobile, Microsoft Excel Mobile, and Microsoft Word Mobile to your private store. It might take up to 36 hours for the apps to appear in the private store. These apps are automatically available for you to deploy to users.
+
+    >  **Note:** When you sign up for Microsoft Store for Business, the portal automatically adds Microsoft Sway, Microsoft OneNote, Microsoft PowerPoint Mobile, Microsoft Excel Mobile, and Microsoft Word Mobile to your private store. It might take up to 36 hours for the apps to appear in the private store. These apps are automatically available for you to deploy to users.
+
 8. In the navigation pane, select  **Settings**. In the details pane, on the  **Shop** tab, in the **Shopping experience** section, turn the **Show offline apps** switch to **On**.
 
 9. Verify that under  **Microsoft Store for Business**, the second option from the left on the toolbar is  **Default Directory**.
 
-10. In the details pane, select the  **Distribute** tab. In the **Private store** section, select **Change**, in the  **Display name** text box, ** **type  **Adatum Store**, and then select  **Save**.
+10. In the details pane, select the  **Distribute** tab. In the **Private store** section, select **Change**, in the  **Display name** text box, type  **Adatum Store**, and then select  **Save**.
 
 11. Verify that the second option from the left on the toolbar below  **Microsoft Store for Business** is now **Adatum Store**. This is your private store.
 
 12. In the  **Settings** details pane, select the **Devices** tab, and then review where you can configure Device Guard signer policies. Don’t confuse this option with the **Devices** option in the navigation pane!
 
->  **Note:** When configured, these policies allow apps from Microsoft Store for Business to run on a device that Windows Defender Device Guard is protecting.
+   >  **Note:** When configured, these policies allow apps from Microsoft Store for Business to run on a device that Windows Defender Device Guard is protecting.
+
 
 
 #### Task 2: Work with roles in Microsoft Store for Business
@@ -42,33 +51,45 @@
 
 4. Select  **Assign roles**, in the text box, type  **Holly**, select  **Holly Spencer**, select the  **Purchaser** check box, and then select **Save**.
 
-5. In the details pane, verify that the GAdmin user has the Global Admin ** **role, ** **Ada Russell ** **has the Admin ** **role, and Holly Spencer ** **has the Purchaser role.
+5. In the details pane, verify that the GAdmin user has the Global Admin role, Ada Russell has the Admin role, and Holly Spencer has the Purchaser role.
 
 6. On  **LON-CL1**, on the taskbar, select  **Internet Explorer**.
 
-7. In Internet Explorer, in the address bar, type  **https://www.microsoft.com/business-store**, and then press Enter.
+7. In Internet Explorer, in the address bar, type  [**https://www.microsoft.com/business-store**](https://www.microsoft.com/business-store), and then press Enter.
 
 8. In the top-right corner of Internet Explorer, select the  **Sign in** link.
->  **Note:** The page localizes based on your location.
-9. On the  **Sign in toMicrosoft Store** page, in the **someone@example.com** text box, type **Holly@YourInitialsMMDDYYoutlook.onmicrosoft.com**, select  **Next**, in the  **Password** text box, type **Pa55w.rd**, ** **and then select  **Sign in**. At the  **Would you like to store your password for microsoftonline.com** notification, select **Not for this site**.
->  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the _YourInitials-MMDDYY_@outlook.com format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF-121817@outlook.com. In this case, you should sign in as  **Holly@DF121817outlook.onmicrosoft.com**.
-10. Maximize the  **Internet Explorer** window, and then select **Manage**. Verify that in the navigation pane, Holly has the  **Quotes**, ** Products &amp; services**,  **My organization**,  **Benefits**,  **Billing, Order history**, ** Partners**, and  **Support** options available.
->  **Note:** Holly has the Purchaser role assigned. Purchaser doesn’t have access to **Devices**, ** Permissions**, and  **Settings**.
-11. In Internet Explorer, select  **Shop for my group**, scroll down to the  **Made by Microsoft** section, select **Translator**, select  **Get the app**, and then select  **Close**. Notice the ellipsis ( **…**) near the  **Install** button.
 
-12. Select the ellipsis ( **…**), and then notice that only the  **Manage** option is available. Additionally, notice that **License type** is set to **Online**, but the  **Offline** licensing type also is available.
->  **Note:** Holly has the Purchaser role assigned. Purchaser can’t add apps to the private store.
-13. On  **LON-CL2**, in Microsoft Edge, on the toolbar below  **Microsoft Store for Business**, select  **Manage**. Verify that in the navigation pane, you have the  **Quotes**, ** Products &amp; services**,  **My organization**,  **Benefits**,  **Devices**,  **Billing**, ** Order history**,  **Partners**,  **Permissions**,  **Settings**, ** **and  **Support** options available.
->  **Note:** The GAdmin user is a global administrator and has full permissions in Microsoft Store for Business.
+    >  **Note:** The page localizes based on your location.
+
+9. On the  **Sign in toMicrosoft Store** page, in the **someone@example.com** text box, type **Holly@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**, select  **Next**, in the  **Password** text box, type **Pa55w.rd**, and then select  **Sign in**. At the  **Would you like to store your password for microsoftonline.com** notification, select **Not for this site**.
+
+    >  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the **_&lt;YourInitials&gt;&lt;MMDDYY&gt;_@outlook.com** format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF-121817@outlook.com. In this case, you should sign in as  **Holly@DF121817outlook.onmicrosoft.com**.
+
+10. Maximize the  **Internet Explorer** window, and then select **Manage**. Verify that in the navigation pane, Holly has the  **Quotes**, **Products &amp; services**,  **My organization**,  **Benefits**,  **Billing, Order history**, **Partners**, and  **Support** options available.
+
+    >  **Note:** Holly has the Purchaser role assigned. Purchaser doesn’t have access to **Devices**, **Permissions**, and  **Settings**.
+
+11. In Internet Explorer, select  **Shop for my group**, scroll down to the  **Made by Microsoft** section, select **Translator**, select  **Get the app**, and then select  **Close**. Notice the ellipsis (**…**) near the  **Install** button.
+
+12. Select the ellipsis (**…**), and then notice that only the  **Manage** option is available. Additionally, notice that **License type** is set to **Online**, but the  **Offline** licensing type also is available.
+
+    >  **Note:** Holly has the Purchaser role assigned. Purchaser can’t add apps to the private store.
+
+13. On  **LON-CL2**, in Microsoft Edge, on the toolbar below  **Microsoft Store for Business**, select  **Manage**. Verify that in the navigation pane, you have the  **Quotes**, **Products &amp; services**,  **My organization**,  **Benefits**,  **Devices**,  **Billing**, **Order history**,  **Partners**,  **Permissions**,  **Settings**, and  **Support** options available.
+
+    >  **Note:** The GAdmin user is a global administrator and has full permissions in Microsoft Store for Business.
+
 14. In Microsoft Edge, select  **Shop for my group**, scroll down to the  **Made by Microsoft** section, and then select **Translator**. 
 
-15. Select the ellipsis ( **…**), and then notice that you can see the  **Manage** and **Add to private store** options available. Select **Add to private store**.
->  **Note:** All store apps support online licensing. Only some store apps support offline licensing; the developer who submits the app to the store decides if the app can be offline-licensed.
-16. In Microsoft Edge, select  **Shop for my group**, scroll down to the  **Made by Microsoft** section, select **Show all**, ** **select  **Fresh Paint**, select  **Get the app**, and then select  **Close**.
+15. Select the ellipsis (**…**), and then notice that you can see the  **Manage** and **Add to private store** options available. Select **Add to private store**.
 
-17. In Microsoft Edge, select  **Shop for my group**, scroll down to the  **Made by Microsoft** section, select **Show all**, ** **and then select  **Microsoft Remote Desktop**.
+    >  **Note:** All store apps support online licensing. Only some store apps support offline licensing; the developer who submits the app to the store decides if the app can be offline-licensed.
 
-18. On the  **Microsoft Remote Desktop** page, in the **License type: Online** drop-down list, select **Offline**. Select  **Get the app**, select  **Close**, ** **select  **Manage**, scroll down the page, and then verify that you can download the Microsoft Remote Desktop package for offline use.
+16. In Microsoft Edge, select  **Shop for my group**, scroll down to the  **Made by Microsoft** section, select **Show all**, select  **Fresh Paint**, select  **Get the app**, and then select  **Close**.
+
+17. In Microsoft Edge, select  **Shop for my group**, scroll down to the  **Made by Microsoft** section, select **Show all**, and then select  **Microsoft Remote Desktop**.
+
+18. On the  **Microsoft Remote Desktop** page, in the **License type: Online** drop-down list, select **Offline**. Select  **Get the app**, select  **Close**, select  **Manage**, scroll down the page, and then verify that you can download the Microsoft Remote Desktop package for offline use.
 
 
 
@@ -76,42 +97,51 @@
   
 1. On  **LON-CL1**, select the  **Store** app on the taskbar.
 
-2. In the Store app, verify that you can see the following five categories on the toolbar of the Store ** **app:  **Home**,  **Apps**,  **Games**,  **Movies &amp; TV**, ** **and  **Books**.
+2. In the Store app, verify that you can see the following five categories on the toolbar of the Store app:  **Home**,  **Apps**,  **Games**,  **Movies &amp; TV**, and  **Books**.
 
-3. In the Store ** **app, on the toolbar, select the icon that represents a person (the icon to the left of the magnifying glass), and then select  **Add work or school account**.
+3. In the Store app, on the toolbar, select the icon that represents a person (the icon to the left of the magnifying glass), and then select  **Add work or school account**.
 
-4. On the  **Let’s get you signed in** page, in the **someone@example.com** text box, type **Abbi@YourInitialsMMDDYYoutlook.onmicrosoft.com**, and then select  **Next**.
->  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the _YourInitials-MMDDYY_@outlook.com format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF-121817@outlook.com. In this case, you should sign in as  **Abbi@DF121817outlook.onmicrosoft.com**.
+4. On the  **Let’s get you signed in** page, in the **someone@example.com** text box, type **Abbi@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**, and then select  **Next**.
+
+    >  **Note:** If you followed the suggestion in Module 3, “Managing Windows 10 sign-in and identity,” you created a Microsoft account in the **_&lt;YourInitials&gt;&lt;MMDDYY&gt;_@outlook.com** format. For example, if your name is Don Funk and you created a Microsoft account on December 18, 2017, your account should be DF121817@outlook.com. In this case, you should sign in as  **Abbi@DF121817outlook.onmicrosoft.com**.
+
 5. On the  **Enter password** page, in the **Password** text box, type **Pa55w.rd** and then select **Sign in**.
 
 6. On  **Add this account to Windows** page, select **Yes**, and then select  **Done**.
 
-7. In the Store ** **app, on the toolbar, select the icon that represents a person (the icon to the left of the magnifying glass), and then verify that you are signed in as  **Abbi Skinner**.
->  **Note:** Although apps added to the private store when you signed up for Microsoft Store for Business, it takes up to 36 hours for apps to appear in the private store. When they are visible, you will get an additional tab in the Store app. This additional tab will be named **Adatum Store**, which you configured earlier in the lab.
-8. Close the Store ** **app.
+7. In the Store app, on the toolbar, select the icon that represents a person (the icon to the left of the magnifying glass), and then verify that you are signed in as  **Abbi Skinner**.
 
-9. On the taskbar, select  **Start**, type  **work or**, select  **Manage work or school account**, verify that the work or school account ** **that you used in the Store app is connected to your Microsoft account, and then close the Settings ** **app.
->  **Note:** A Microsoft Azure Active Directory (Azure AD) account also is referenced as a work or school account.
+    >  **Note:** Although apps added to the private store when you signed up for Microsoft Store for Business, it takes up to 36 hours for apps to appear in the private store. When they are visible, you 
+will get an additional tab in the Store app. This additional tab will be named **Adatum Store**, which you configured earlier in the lab.
+8. Close the Store app.
+
+9. On the taskbar, select  **Start**, type  **work or**, select  **Manage work or school account**, verify that the work or school account that you used in the Store app is connected to your Microsoft account, and then close the Settings app.
+
+    >  **Note:** A Microsoft Azure Active Directory (Azure AD) account also is referenced as a work or school account.
+
 10. On the taskbar, select  **Start**, type  **gpedit.msc**, and then press Enter.
 
 11. In the  **Local Group Policy Editor**, in the navigation pane, under  **Computer Configuration**, expand  **Administrative Templates**, expand  **Windows Components**, and then select  **Store**.
 
 12. In the details pane, double-click the  **Only display the private store within the Windows Store app** setting, read the Help for the setting, select **OK**, and then close the  **Local Group Policy Editor**.
 
->  **Note:** You don’t configure and test this setting, because the private store has not yet updated with the added apps.
+    >  **Note:** You don’t configure and test this setting, because the private store has not yet updated with the added apps.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have successfully signed up for Microsoft Store for Business and performed initial configuration of the store. You should also have assigned users to Microsoft Store for Business roles and tested how to connect to the store from Windows 10 devices.
+
 
 
 ## Exercise 2: Configuring and using Windows AutoPilot
   
 #### Task 1: Customize Azure AD company branding
   
-1. On  **LON-DC1**, on the taskbar, click  **Internet Explorer**. ** **
+1. On  **LON-DC1**, on the taskbar, click  **Internet Explorer**. 
 
-2. In Internet Explorer, in the address bar, type  **https://portal.azure.com**, and then press Enter.
+2. In Internet Explorer, in the address bar, type  [**https://portal.azure.com**](https://portal.azure.com), and then press Enter.
 
-3. In the  **Sign in toMicrosoft Azure** dialog box, in the **Email or phone** text box, type **GAdmin@YourInitialsMMDDYYoutlook.onmicrosoft.com**, select  **Next**, ** **in the  **Password** text box, type the password that you have configured for this user in module 3, ** **select ** Sign** and then select **No**.
+3. In the  **Sign in toMicrosoft Azure** dialog box, in the **Email or phone** text box, type **GAdmin@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**, select  **Next**, in the  **Password** text box, type the password that you have configured for this user in module 3, select **Sign** and then select **No**.
 
 4. In the Microsoft Azure portal, in the navigation pane, select  **Azure Active Directory**.
 
@@ -119,8 +149,7 @@
 
 6. On the  **Configure company branding** blade, configure the following settings:
 
-
-  - Sign-in page background image: Select  **Browse**, browse to  **E:\Labfiles\Mod08**, select  **Background.jpg**, and then select  **Open**.
+  - Sign-in page background image: Select  **Browse**, browse to  **E:\\Labfiles\\Mod08**, select  **Background.jpg**, and then select  **Open**.
 
   - Banner logo: Select the  **Browse** icon, select **Adatum280.jpg**, and then select  **Open**.
 
@@ -132,18 +161,17 @@
 
   - Show option to remain signed in: Select  **Yes**.
 
-
-7. Select  **Save**, ** **and then close the  **Configure company branding** blade.
+7. Select  **Save**, and then close the  **Configure company branding** blade.
 
 8. On the  **Azure Active Directory** blade, in the navigation pane, select **Properties**.
 
-9. In the  **Name** text box, type **20697-2C Azure AD**, ** **and then select  **Save**.
+9. In the  **Name** text box, type **20697-2C Azure AD**, and then select  **Save**.
 
 
 
 #### Task 2: Generate a device-specific comma-separated value (CSV) file
   
-1. On  **LON-CL5**, on the taskbar, right-click  **Start**, select  **Windows PowerShell (Admin)**, ** **and then select  **Yes**.
+1. On  **LON-CL5**, on the taskbar, right-click  **Start**, select  **Windows PowerShell (Admin)**, and then select  **Yes**.
 
 2. In the Windows PowerShell command-line interface, type the following cmdlet, and then press Enter:
 
@@ -151,7 +179,7 @@
   Install-Script -Name Get-WindowsAutoPilotInfo
   ```
 
-3. You will receive three prompts. Each time, type  **Y**, ** **and then press Enter.
+3. You will receive three prompts. Each time, type  **Y**, and then press Enter.
 
 4. Type the following cmdlet, and then press Enter:
 
@@ -159,15 +187,15 @@
   Set-ExecutionPolicy RemoteSigned
   ```
 
-5. When prompted, type  **Y**, ** **and then press Enter.
+5. When prompted, type  **Y**, and then press Enter.
 
 6. Type the following cmdlet, and then press Enter:
 
   ```
-  Get-WindowsAutoPilotInfo.ps1 –OutputFile C:\Computer.csv
+  Get-WindowsAutoPilotInfo.ps1 -OutputFile C:\Computer.csv
   ```
 
-7. Type  **type C:\Computer.csv**, press Enter, ** **and then review the file content.
+7. Type  **type C:\\Computer.csv**, press Enter, and then review the file content.
 
 8. Type the following command, and then press Enter:
 
@@ -188,23 +216,21 @@ Copy C:\Computer.csv F:\
   
 1. On  **LON-CL2**, in  **Microsoft Edge**, on the  **Microsoft Store for Business** page, in the navigation pane, select **Devices**.
 
-2. In the details pane, select  **Add devices**, browse to  **\\LON-DC1\Labfiles**, select  **Computer.csv**, and then select  **Open**.
+2. In the details pane, select  **Add devices**, browse to  **\\\\LON-DC1\\Labfiles**, select  **Computer.csv**, and then select  **Open**.
 
 3. In the  **Add device to an AutoPilot deployment group** dialog box, select **No, thanks**.
 
 4. In the details pane, select  **Refresh my list**, and then verify that  **Virtual Machine** is added.
 
-5. Select  **AutoPilot deployment**, ** **and then select  **Create new profile**.
+5. Select  **AutoPilot deployment**, and then select  **Create new profile**.
 
-6. In the details pane, in the  **Enter a profile name** text box, type **Profile1**, ** **turn the switch to  **On** for the following three options, and then select **Create**:
-
+6. In the details pane, in the  **Enter a profile name** text box, type **Profile1**, turn the switch to  **On** for the following three options, and then select **Create**:
 
   -  **Skip privacy settings**
 
   -  **Disable local admin account creation on the device**
 
   -  **Skip End User License Agreement (EULA)**
-
 
 7. Select the  **Virtual Machine** check box, select **AutoPilot deployment**, and then select  **Apply Profile1**.
 
@@ -214,11 +240,11 @@ Copy C:\Computer.csv F:\
 
 #### Task 4: Deploy a device by using Windows AutoPilot
   
-1. On the host computer, in  **Hyper-V Manager**, in the  **Virtual Machines** section, select **20697-2C-LON-CL5**, ** **in the  **Checkpoints** section, right-click **Generalized**, and then select  **Apply** twice.
+1. On the host computer, in  **Hyper-V Manager**, in the  **Virtual Machines** section, select **20697-2C-LON-CL5**, in the  **Checkpoints** section, right-click **Generalized**, and then select  **Apply** twice.
 
 2. In Hyper-V Manager, in details pane, double-click on  **20697-2C-LON-CL5**.
 
-3. In the  **20697-2C-LON-CL5** window, select **Action**, ** **and then select  **Start** to turn on the virtual machine (VM).
+3. In the  **20697-2C-LON-CL5** window, select **Action**, and then select  **Start** to turn on the virtual machine (VM).
 
 4. Wait while  **LON-CL5** starts.
 
@@ -228,9 +254,9 @@ Copy C:\Computer.csv F:\
 
 7. On the  **Want to add a second keyboard layout?** page, select **Skip**.
 
-8. On the  **Welcome to 20697-2C Azure AD** page, verify that the page is customized with the Adatum company branding that you added earlier. In the **someone@example.com** text box, type **Abbi@yourinitialsMMDDYYoutlook.onmicrosoft.com**, ** **and then select  **Next**.
+8. On the  **Welcome to 20697-2C Azure AD** page, verify that the page is customized with the Adatum company branding that you added earlier. In the **someone@example.com** text box, type **Abbi@*&lt;YourInitials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**, and then select  **Next**.
 
-9. On the  **Enter your password** page, verify that a custom graphic is present, in addition to text on the bottom of the page. In the **Password** text box, type **Pa55w.rd**, ** **and then select  **Next**.
+9. On the  **Enter your password** page, verify that a custom graphic is present, in addition to text on the bottom of the page. In the **Password** text box, type **Pa55w.rd**, and then select  **Next**.
 
 >  **Note:** While Abbi is signing in, notice that you weren’t asked for privacy settings. You disabled that in the Windows AutoPilot deployment profile.
 
@@ -244,16 +270,19 @@ Copy C:\Computer.csv F:\
 >  **Result**: After completing this exercise, you should have successfully implemented Azure AD company branding. You should also have successfully implemented Windows AutoPilot Deployment and used it to deploy Windows 10 devices.
 
 
+
 ## Exercise 3: Using Microsoft Store for Business to deploy apps
   
 #### Task 1: Assign a Microsoft Store for Business app
   
-1. On  **LON-CL5**, where you are signed in as  **Abbi**, on the taskbar, select  **Start**, type  **internet**, ** **and then select  **Internet Explorer**.
+1. On  **LON-CL5**, where you are signed in as  **Abbi**, on the taskbar, select  **Start**, type  **internet**, and then select  **Internet Explorer**.
 
 2. In Internet Explorer, select the  **Use recommended security and compatibility settings** option, and then select **OK**.
 
-3. In Internet Explorer, in the address bar, type  **https://portal.office.com**, and then press Enter. 
->  **Note:** You signed in to Office portal as Abbi Skinner, although you weren’t asked for credentials. You are signed in to **LON-CL5** with an Azure AD account, and the same account is used to access the Office portal.
+3. In Internet Explorer, in the address bar, type  [**https://portal.office.com**](https://portal.office.com), and then press Enter. 
+
+    >  **Note:** You signed in to Office portal as Abbi Skinner, although you weren’t asked for credentials. You are signed in to **LON-CL5** with an Azure AD account, and the same account is used to access the Office portal.
+
 4. On the  **Microsoft Office Home** page, select **Mail**.
 
 5. On the  **Outlook** page, select your language, select the time zone and then select **Save**.
@@ -262,7 +291,7 @@ Copy C:\Computer.csv F:\
 
 7. In the details pane, select  **Fresh Paint**, and then select  **Assign Users**.
 
-8. In the  **Assign to people** dialog box, in the **Enter a name or email address** text box, type **abbi**, select  **Abbi Skinner**, ** **and then select  **Assign**.
+8. In the  **Assign to people** dialog box, in the **Enter a name or email address** text box, type **abbi**, select  **Abbi Skinner**, and then select  **Assign**.
 
 9. Scroll down and verify that Abbi Skinner appears in the  **Users** section.
 
@@ -280,14 +309,15 @@ Copy C:\Computer.csv F:\
 
 16. Close the Microsoft Store app by pressing ALT+F4.
 
-17. On  **LON-CL1**, in Internet Explorer, in the  **Users** section, in the row in which **Abbi Skinner** appears, on the right of the window, select the ellipsis ( **…**) in the  **Manage** column, select **Reclaim license**, ** **and then select  **Reclaim licenses**. Verify that Abbi Skinner no longer appears in the  **Users** section.
+17. On  **LON-CL1**, in Internet Explorer, in the  **Users** section, in the row in which **Abbi Skinner** appears, on the right of the window, select the ellipsis (**…**) in the  **Manage** column, select **Reclaim license**, and then select  **Reclaim licenses**. Verify that Abbi Skinner no longer appears in the  **Users** section.
 
->  **Note:** You reclaimed the license for the Fresh Paint app from Abbi Skinner. If the app weren’t free, Abbi would not be allowed to run the app.
+    >  **Note:** You reclaimed the license for the Fresh Paint app from Abbi Skinner. If the app weren’t free, Abbi would not be allowed to run the app.
+
 
 
 #### Task 2: Prepare for the next module
   
- When you finish with the lab, revert the  **LON-CL1**,  **LON-CL2** and **LON-CL5** VMs to their initial state. *Don’t* revert **LON-DC1**: 
+ When you finish with the lab, revert the  **LON-CL1**,  **LON-CL2** and **LON-CL5** VMs to their initial state. **_Don’t revert LON-DC1!_** 
 
 1. On the host computer, start  **Hyper-V Manager**.
 
@@ -295,12 +325,16 @@ Copy C:\Computer.csv F:\
 
 3. In the  **Revert Virtual Machine** dialog box, select **Revert**.
 
-4. Repeat steps 2 and 3 for  **20697-2C-LON-CL2** and ** 20697-2C-LON-CL5**.
+4. Repeat steps 2 and 3 for  **20697-2C-LON-CL2** and **20697-2C-LON-CL5**.
 
->  **Note:** *Don’t* revert **LON-DC1**!  **LON-DC1** is synchronizing on-premises Active Directory Domain Services (AD DS) with Azure AD.
+    >  **Note:** **_Don’t revert LON-DC1!_**  **LON-DC1** is synchronizing on-premises Active Directory Domain Services (AD DS) with Azure AD.
+
+<!-- -->
 
 >  **Result**: After finishing this exercise, you will assign and install an app from Microsoft Store for Business. You will also reclaim the app license.
 
+
+##  
 
 
 ©2016 Microsoft Corporation. All rights reserved.

--- a/Instructions/206972C_LAB_AK_09.md
+++ b/Instructions/206972C_LAB_AK_09.md
@@ -1,18 +1,19 @@
-# Lab Answer Key:  Module 9: Deploying apps and managing information access by using Intune
+﻿# Lab Answer Key:  Module 9: Deploying apps and managing information access by using Intune
 # Lab: Deploying apps and managing information access by using Intune
   
 ## Exercise 1: Deploying apps by using Intune
   
 #### Task 1: Create an app category
   
-1. On  **LON-CL3**, open Microsoft Edge, and navigate to  **http://portal.azure.com**.
+1. On  **LON-CL3**, open Microsoft Edge, and navigate to  [**https://portal.azure.com**](https://portal.azure.com).
 
 2. Sign in with the following account:
-Username:  **GAdmin** _@initialsMMDDYY_ ** _.onmicrosoft.com_**
 
-Password: The password you created in Module 3
+- Username:  **GAdmin@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**
 
-3. In the navigation pane, select  **More services**.
+- Password: The password you created in Module 3
+
+3. In the navigation pane, select  **All services**.
 
 4. In the  **Search** box, type **Intune**, and then select  **Intune** from the results.
 
@@ -38,9 +39,9 @@ Password: The password you created in Module 3
 
   - IT department email address:  **IT@adatum.com**
 
-  - Company privacy statement URL:  **http://adatum.sharepoint.com/IT/Privacy**
+  - Company privacy statement URL:  **https://adatum.sharepoint.com/IT/Privacy**
 
-  - Support website URL:  **http://adatum.sharepoint.com/IT/Support**
+  - Support website URL:  **https://adatum.sharepoint.com/IT/Support**
 
 3. Support website name:  **Adatum helpdesk**
 
@@ -48,11 +49,11 @@ Password: The password you created in Module 3
 
 5. Next to  **Select a logo to use on light backgrounds**, select the  **Browse** icon.
 
-6. Navigate to  **C:\Labfiles\Mod09\Adatumlogo.png**, and then select  **Open**.
+6. Navigate to  **C:\\Labfiles\\Mod09\\Adatumlogo.png**, and then select  **Open**.
 
 7. Next to  **Select a logo to use on dark backgrounds**, select the  **Browse** icon and repeat step 5.
 
-8. Clear the  **Show company name next to logo** check box, ** **and then select  **Save**.
+8. Clear the  **Show company name next to logo** check box, and then select  **Save**.
 
 
 
@@ -64,7 +65,7 @@ Password: The password you created in Module 3
 
 2. Sign in with the following account:
 
-  - Username:  **GAdmin@** _initialsMMDDYY_ ** _.onmicrosoft.com_**
+  - Username:  **GAdmin@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**
 
   - Password: The password you created in Module 3
 
@@ -77,17 +78,19 @@ Password: The password you created in Module 3
 
   **Synchronize Intune with the Microsoft Store for Business**
 
-1. In Microsoft Edge, switch to the  **Dashboard – Microsoft Azure** tab.
 
-2. In the  **Mobile apps** workspace, select Microsoft Store for Business.
+6. In Microsoft Edge, switch to the  **Dashboard – Microsoft Azure** tab.
 
-3. Select  **Enable**, and then verify  **English** is selected.
+7. In the  **Mobile apps** workspace, select Microsoft Store for Business.
 
-4. Select  **Save**, and then select  **Sync**.
+8. Select  **Enable**, and then verify  **English** is selected.
 
-5. In the  **Mobile apps** workspace, select **Apps** to view the list of available apps.
+9. Select  **Save**, and then select  **Sync**.
 
->  **Note:** You should see the apps added in Module 8. It might take some time for the apps to sync.
+10. In the  **Mobile apps** workspace, select **Apps** to view the list of available apps.
+
+    >  **Note:** You should see the apps added in Module 8. It might take some time for the apps to sync.
+
 
 
 #### Task 4: Add apps to Intune and assign to devices
@@ -100,8 +103,7 @@ Password: The password you created in Module 3
 
 3. Select  **Configure App Suite**.
 
-4. Select the following Office 365 apps, and then select ** OK**:
-
+4. Select the following Office 365 apps, and then select **OK**:
 
   -  **Excel**
 
@@ -113,10 +115,9 @@ Password: The password you created in Module 3
 
   -  **PowerPoint**
 
+  -  **Skype for Business**
 
--  **Skype for Business**
-
--  **Word**
+  -  **Word**
 
 5. Select  **App Suite Information**, and then in the  **Suite Name** text box, type **Adatum standard Office install**.
 
@@ -140,7 +141,7 @@ Password: The password you created in Module 3
 
 15. Select  **Select**.
 
-16. Under  **Type**, select  **Available**, ** **and then select  **Save**.
+16. Under  **Type**, select  **Available**, and then select  **Save**.
 
 
   **Add an LOB app to Intune**
@@ -149,29 +150,29 @@ Password: The password you created in Module 3
 
 18. Select  **Add**, and then in the  **App type** list, select **Line-of-business app**.
 
-19. Select  **App package file**, ** **and then select the  **Browse** icon.
+19. Select  **App package file**, and then select the  **Browse** icon.
 
-20. Navigate to  **C:\Labfiles\Mod09\XMLNotepad.msi**, and then select ** Open**.
+20. Navigate to  **C:\\Labfiles\\Mod09\\XMLNotepad.msi**, and then select **Open**.
 
 21. Select  **OK**, and then select  **App information**.
 
 22. In the  **Description** text box, type **XML text editor for the IT team**.
 
-23. In the  **Publisher** text ** **box, type  **Microsoft**.
+23. In the  **Publisher** text box, type  **Microsoft**.
 
 24. In the  **Category** list, select **IT tools**.
 
-25. In the  **Information URL** text box, type **http://adatum.sharepoint.com/IT/Tools**.
+25. In the  **Information URL** text box, type **https://adatum.sharepoint.com/IT/Tools**.
 
-26. In the  **Privacy URL** text box, type **http://adatum.sharepoint.com/IT/privacy.**
+26. In the  **Privacy URL** text box, type **https://adatum.sharepoint.com/IT/privacy.**
 
 27. In the  **Developer** text box, type **Microsoft**, and then in the  **Owner** text box, type **Adatum IT**. 
 
-28. Under  **Logo**, ** **select  **Select image**.
+28. Under  **Logo**, select  **Select image**.
 
 29. Select the  **Browse** icon.
 
-30. Navigate to  **C:\Labfiles\Mod09\notepad.png**, ** **and then select  **Open**.
+30. Navigate to  **C:\\Labfiles\\Mod09\\notepad.png**, and then select  **Open**.
 
 31. Select  **OK** twice, and then select **Add**.
 
@@ -191,11 +192,13 @@ Password: The password you created in Module 3
 
 2. Select  **Accounts** and then select **Access work or school**.
 
-3. Under work or school account select  **Abbi@** _initialsMMDDYY_ ** _.onmicrosoft.com_** and select **Info**.
+3. Under work or school account select  **Abbi@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** and select **Info**.
 
 4. Select  **Sync**.
 
->  **Note:** Wait for the settings to sync and for XML Notepad 2007 to install. XML A link to XML Notepad 2007 will appear on the Desktop.
+    >  **Note:** Wait for the settings to sync and for XML Notepad 2007 to install. XML A link to XML Notepad 2007 will appear on the Desktop.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have successfully:Created an app category in Intune.Customized the Company Portal.Synchronized Intune with the Microsoft Store for Business, added Microsoft Store for Business apps to Intune.Added Office 365 ProPlus and LOB apps to Intune, and assigned them to a device group.Installed an app from the Company portal.
 
@@ -206,7 +209,7 @@ Password: The password you created in Module 3
   
 1. On  **LON-CL3**, in Microsoft Edge, switch to the  **Dashboard – Microsoft Azure** tab.
 
-2. In the navigation pane, select  **More services**.
+2. In the navigation pane, select  **All services**.
 
 3. In the  **Search** box, type **Intune**, and then select  **Intune** from the results.
 
@@ -236,7 +239,7 @@ Password: The password you created in Module 3
 
 6. Select  **Allow overrides**.
 
-7. In the  **Corporate identity** text box, type **adatum.com**, and then select  **OK**.
+7. In the  **Corporate identity** text box, type **Adatum.com**, and then select  **OK**.
 
 
 
@@ -272,15 +275,15 @@ Password: The password you created in Module 3
   Cipher /rc:\users\admin\documents\ADATUMDRA
   ```
 
-3. When prompted, type  **Pa55w.rd**, ** **and then confirm the password.
+3. When prompted, type  **Pa55w.rd**, and then confirm the password.
 
 4. Switch to Microsoft Edge, and under  **Data protection**, select the  **Browse** icon.
 
 5. Browse to the  **Documents** folder, select the **ADATUMDRA.cer** file, and then select **Open**.
 
-6. Under  **Show the enterprise data protection icon**, select  **On**. ** **
+6. Under  **Show the enterprise data protection icon**, select  **On**. 
 
-7. Select  **OK**, ** **and then select  **Create**.
+7. Select  **OK**, and then select  **Create**.
 
 
 
@@ -298,23 +301,24 @@ Password: The password you created in Module 3
 
 6. Select  **Accounts** and then select **Access work or school**.
 
-7. Under work or school account select  **Abbi@** _initialsMMDDYY_ ** _.onmicrosoft.com_** and select **Info**.
+7. Under work or school account select  **Abbi@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** and select **Info**.
 
 8. Select  **Sync**.
->  **Note:** Wait for the settings to sync.
-9. In Edge, navigate to  _initialsMMDDYY_ ** _.sharepoint.com_**.
+
+    >  **Note:** Wait for the settings to sync.
+
+9. In Edge, navigate to  **https://*&lt;Initials&gt;&lt;MMDDYY&gt;*.sharepoint.com**.
 
 10. If prompted, sign in with the credentials:
 
-
-  - Usename:  **Abbi@** _initialsMMDDYY_ ** _.onmicrosoft.com_**
+  - Usename:  **Abbi@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**
 
   - Password:  **Pa55w.rd**
 
+11. Start Internet Explorer and navigate to  **https://*&lt;Initials&gt;&lt;MMDDYY&gt;*.sharepoint.com**.
 
-11. Start Internet Explorer and navigate to  _initialsMMDDYY_ ** _.sharepoint.com_**.
+    >  **Note:** You should not be able to successfully navigate to the SharePoint site in internet explorer because it is not an allowed app.
 
->  **Note:** You should not be able to successfully navigate to the SharePoint site in internet explorer because it is not an allowed app.
 
 
 #### Task 6: Create a wipe request
@@ -328,7 +332,9 @@ Password: The password you created in Module 3
 4. Select  **Remove company data**.
 
 5. In the  **Remove company data – LON-CL3** dialog, select **Yes**.
->  **Note:** Note that the message **Remove company data pending…** appears in Microsoft Azure.
+
+    >  **Note:** Note that the message **Remove company data pending…** appears in Microsoft Azure.
+
 6. Close Microsoft Edge.
 
 

--- a/Instructions/206972C_LAB_AK_10.md
+++ b/Instructions/206972C_LAB_AK_10.md
@@ -1,11 +1,11 @@
-# Lab Answer Key:  Module 10: Managing data access for Windows-based devices
+﻿# Lab Answer Key:  Module 10: Managing data access for Windows-based devices
 # Lab A: Implementing and using Work Folders
   
 ## Exercise 1: Configuring Work Folders
   
 #### Task 1: Configure infrastructure requirements
   
-1. On  **LON-DC1**, right-click  **Start**, and then select ** Windows PowerShell (Admin)**.
+1. On  **LON-DC1**, right-click  **Start**, and then select **Windows PowerShell (Admin)**.
 
 2. In the  **Windows PowerShell** command-line interface, type the following cmdlet, and then press Enter.
 
@@ -19,15 +19,17 @@
 
 5. In the  **WORK FOLDERS** section, select **TASKS**, and then select  **New Sync Share**.
 
-6. In the  **New Sync Share Wizard**, ** **on the  **Before you begin** page, select **Next**.
+6. In the  **New Sync Share Wizard**, on the  **Before you begin** page, select **Next**.
 
-7. On the  **Select the server and path** page, in the **Enter a local path** text box, type **C:\syncshare1**, select  **Next**, and then select  **OK** to create the folder.
->  **Note:** If **LON-DC1** is not listed in the **Servers** section, select **Cancel**. In Server Manager, select ** Refresh**, and then repeat this task beginning with step 5.
-8. On the  **Specify the structure for user folders** page, ** **verify that  **User alias** is selected, and then select **Next**.
+7. On the  **Select the server and path** page, in the **Enter a local path** text box, type **C:\\syncshare1**, select  **Next**, and then select  **OK** to create the folder.
+
+    >  **Note:** If **LON-DC1** is not listed in the **Servers** section, select **Cancel**. In Server Manager, select **Refresh**, and then repeat this task beginning with step 5.
+
+8. On the  **Specify the structure for user folders** page, verify that  **User alias** is selected, and then select **Next**.
 
 9. On the  **Enter the sync share name** page, select **Next** to accept the default sync share name.
 
-10. On the  **Grant sync access to groups** page, click **Add**, and in the  **Enter the object name to select** text box, type **Managers**, select  **OK**, ** **and then select  **Next**.
+10. On the  **Grant sync access to groups** page, click **Add**, and in the  **Enter the object name to select** text box, type **Managers**, select  **OK**, and then select  **Next**.
 
 11. On the  **Specify security policies for PCs** page, verify the two available options. Clear the **Automatically lock screen, and require a password** check box, and then select **Next**.
 
@@ -39,11 +41,11 @@
 
 15. On  **LON-DC1**, in  **Server Manager**, select  **Tools,** and then select **Internet Information Services (IIS) Manager**.
 
-16. In  **Internet Information Services (IIS) Manager**, in the navigation pane, expand  **LON-DC1 (ADATUM\Administrator)**. Expand  **Sites**, ** **right-click  **Default Web Site**, and then select  **Edit Bindings**.
+16. In  **Internet Information Services (IIS) Manager**, in the navigation pane, expand  **LON-DC1 (ADATUM\\Administrator)**. Expand  **Sites**, right-click  **Default Web Site**, and then select  **Edit Bindings**.
 
 17. In the  **Site Bindings** dialog box, select **Add**.
 
-18. In the  **Add Site Binding** dialog box, in the **Type** box, select **https**. In the  **SSL certificate** box, select **LON-DC1.adatum.com**, ** **select  **OK**, ** **and then select  **Close**.
+18. In the  **Add Site Binding** dialog box, in the **Type** box, select **https**. In the  **SSL certificate** box, select **LON-DC1.adatum.com**, select  **OK**, and then select  **Close**.
 
 19. Close the  **IIS Manager**.
 
@@ -53,13 +55,13 @@
   
 1. On  **LON-DC1**, in  **Server Manager**, select the  **Tools** menu, and then select **Group Policy Management**.
 
-2. In the  **Group Policy Management Console**, in the navigation pane, expand  **Forest: Adatum.com**, expand  **Domains**, expand  **Adatum.com**, ** **and then select  **Managers**. 
+2. In the  **Group Policy Management Console**, in the navigation pane, expand  **Forest: Adatum.com**, expand  **Domains**, expand  **Adatum.com**, and then select  **Managers**. 
 
 3. Right-click  **Managers**, and then select  **Create a GPO in this domain, and Link it here**. 
 
 4. In the  **Name** text box, type **Deploy Work Folders**, and then select  **OK**.
 
-5. Right-click  **Deploy Work Folders**, ** **and then select  **Edit**.
+5. Right-click  **Deploy Work Folders**, and then select  **Edit**.
 
 6. In the  **Group Policy Management Editor**, under  **User Configuration**, in the navigation pane, expand  **Policies**, expand  **Administrative Templates**, expand  **Windows Components**, and then select the  **Work Folders** node.
 
@@ -75,27 +77,27 @@
 
 12. Sign out of  **LON-CL2**.
 
-13. Sign back in as  **adatum\adam** with the password **Pa55w.rd**.
+13. Sign back in as  **adatum\\adam** with the password **Pa55w.rd**.
 
 14. On the desktop, on the taskbar, click the  **File Explorer** icon.
 
 15. In the navigation pane, click  **Work Folders**.
 
-16. Right-click in the details pane, select  **New**, select  **Text Document**, and then name the file ** On LON-CL2**.
+16. Right-click in the details pane, select  **New**, select  **Text Document**, and then name the file **On LON-CL2**.
 
 
 
 #### Task 3: Import the Adatum CA root certificate to LON-CL4
   
-1. On  **LON-CL4**, sign out and then sign in as  **LON-CL4\Admin**.
+1. On  **LON-CL4**, sign out and then sign in as  **LON-CL4\\Admin**.
 
 2. Right-click  **Start**, and then click  **Windows PowerShell (Admin)**.
 
 3. Click  **Yes** in the **User Account Control** dialog box.
 
-4. In the  **Command Prompt** window, type **Net Use J: \\lon-dc1\certenroll**, and then press  **Enter**. 
+4. In the  **Command Prompt** window, type **Net Use J: \\\\lon-dc1\\certenroll**, and then press  **Enter**. 
 
-5. When you receive a prompt for a user name, type  **Adatum\Administrator**, and then press  **Enter**.
+5. When you receive a prompt for a user name, type  **Adatum\\Administrator**, and then press  **Enter**.
 
 6. When you receive a prompt for a password, type  **Pa55w.rd**, and then press  **Enter**.
 
@@ -121,7 +123,7 @@
 
 17. In the  **Certificate Import Wizard**, select  **Next**.
 
-18. On the  **Files to Import** page, select **Browse**, click  **certenroll (\\lon-dc1) (J:)**, select the  **LON-DC1.Adatum.com_AdatumCA.crt** file, select **Open**, and then select  **Next**. 
+18. On the  **Files to Import** page, select **Browse**, click  **certenroll (\\\\lon-dc1) (J:)**, select the  **LON-DC1.Adatum.com_AdatumCA.crt** file, select **Open**, and then select  **Next**. 
 
 19. On the  **Certificate Store** page, select **Place all certificates in the following store**, and then select  **Browse**.
 
@@ -137,13 +139,13 @@
   
 1. On  **LON-CL4**, select  **Start**, type  **Work Folders**, and then select  **Work Folders**. 
 
-2. On the  **Manage Work Folders** page, ** **click  **Set up Work Folders**.
+2. On the  **Manage Work Folders** page, click  **Set up Work Folders**.
 
 3. On the  **Enter your work email address** page, select **Enter a Work Folders URL instead**.
 
 4. On the  **Enter a Work Folders URL** page, in the **Work Folders URL** text box, type **https://lon-dc1.adatum.com**, and then select  **Next**.
 
-5. In the  **Windows Security** dialog box, in the **User name** text box, type **adatum\adam**. In the  **Password** text box, type **Pa55w.rd**, ** **and then click  **OK**.
+5. In the  **Windows Security** dialog box, in the **User name** text box, type **adatum\\adam**. In the  **Password** text box, type **Pa55w.rd**, and then click  **OK**.
 
 6. On the  **Introducing Work Folders** page, review the local Work Folders location, and then click **Next**.
 
@@ -157,18 +159,19 @@
 
 #### Task 5: Perform Work Folders synchronization
   
-1. On  **LON-CL4**, in  **Work Folders**, right-click in the details pane, click  **New**, click  **Text Document**, then in the  **Name** text box, type ** On LON-CL4**, and then press Enter.
+1. On  **LON-CL4**, in  **Work Folders**, right-click in the details pane, click  **New**, click  **Text Document**, then in the  **Name** text box, type **On LON-CL4**, and then press Enter.
 
-2. On  **LON-CL2**, ** **in  **Work Folders**, verify that the  **On LON-CL4** file is displayed.
+2. On  **LON-CL2**, in  **Work Folders**, verify that the  **On LON-CL4** file is displayed.
 
->  **Note:** In Windows 10, Work Folders synchronizes immediately. In Windows 8.1, it could take up to 10 minutes for synchronization.
+    >  **Note:** In Windows 10, Work Folders synchronizes immediately. In Windows 8.1, it could take up to 10 minutes for synchronization.
+
 3. On the taskbar, right-click the  **Start** button, and then click **Network Connections**.
 
-4. In the  **Settings** window, click **Change adapter options**. ** **
+4. In the  **Settings** window, click **Change adapter options**. 
 
 5. Right-click  **Ethernet**, and then click  **Disable**. 
 
-6. In the  **User Account Control** dialog box, in the **User name** text box, type **Administrator**. In the  **Password** text box, type ** Pa55w.rd**, and then click  **Yes**.
+6. In the  **User Account Control** dialog box, in the **User name** text box, type **Administrator**. In the  **Password** text box, type **Pa55w.rd**, and then click  **Yes**.
 
 7. On  **LON-CL2**, in  **Work Folders**, double-click  **On LON-CL2**.
 
@@ -176,7 +179,7 @@
 
 9. Close  **Notepad**, and when prompted, select  **Save**.
 
-10. In  **Work Folders**, right-click in the details pane, select  **New**, select  **Text Document**, and then name the file ** Offline LON-CL2**.
+10. In  **Work Folders**, right-click in the details pane, select  **New**, select  **Text Document**, and then name the file **Offline LON-CL2**.
 
 11. On  **LON-CL4**, in  **Work Folders**, double-click the  **On LON-CL2.txt** file.
 
@@ -184,13 +187,14 @@
 
 13. Close  **Notepad**, and then select  **Save**.
 
-14. On  **LON-CL2**, in the  **Network Connections** window, right-click **Ethernet**, ** **and then click  **Enable**. 
+14. On  **LON-CL2**, in the  **Network Connections** window, right-click **Ethernet**, and then click  **Enable**. 
 
-15. In the  **User Account Control** dialog box, in the **User name** text box, type **Administrator**. In the  **Password** text box, type ** Pa55w.rd**, and then click  **Yes**.
+15. In the  **User Account Control** dialog box, in the **User name** text box, type **Administrator**. In the  **Password** text box, type **Pa55w.rd**, and then click  **Yes**.
 
-16. Switch to  **Work Folders**, and verify that files display in the details pane, including On LON-CL2 ** **and On LON-CL2-LON-CL2.
+16. Switch to  **Work Folders**, and verify that files display in the details pane, including **On LON-CL2** and **On LON-CL2-LON-CL2**.
 
->  **Note:** Because the file was modified at two locations, a conflict occurred, and one of the copies was renamed.
+    >  **Note:** Because the file was modified at two locations, a conflict occurred, and one of the copies was renamed by appending the name of the computer where the confilct occured.
+
 
 
 #### Task 6: Prepare for the next lab
@@ -210,7 +214,7 @@
   
 1. On  **LON-CL2**, right-click  **Start** and select **Run**.
 
-2. In the  **Run** dialog box, in the **Open** box, type **odopen://sync?useremail=Adam@yourdomain.onmicrosoft.com,** and then select **OK**. (Where yourdomain is the tenant domain that you configured in previous labs.)
+2. In the  **Run** dialog box, in the **Open** box, type **odopen://sync?useremail=Adam@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com,** and then select **OK**. (Using the tenant domain that you configured in previous labs.)
 
 3. In the  **Microsoft OneDrive** window, select **Sign in**.
 
@@ -244,9 +248,9 @@
 
 8. Verify that  **LocalDoc** has the green checkmark icon to show that it is synchronized.
 
-9. Open  **Microsoft Edge**, in the address bar, type  **https://login.microsoftonline.com**, and then press Enter.
+9. Open  **Microsoft Edge**, in the address bar, type  [**https://portal.office.com**](https://portal.office.com), and then press Enter.
 
-10. Sign in as  **Adam@yourdomain.onmicrosoft.com** by using a password of **Pa55w.rd**
+10. Sign in as  **Adam@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** by using a password of **Pa55w.rd**
 
 11. On the  **Microsoft Office Home** page, select **OneDrive**.
 
@@ -284,7 +288,7 @@
 
 8. Right-click  **Book**, and then select  **Properties**.
 
-9. Verify that  **Size on disk** is **0 bytes**, ** **and then select  **OK**.
+9. Verify that  **Size on disk** is **0 bytes**, and then select  **OK**.
 
 10. Double-click  **Book**.
 
@@ -306,7 +310,7 @@
 
 3. In the  **Microsoft Office warning** dialog box, select **Yes**.
 
-4. On the  **Sign in** page, type **Adam@yourdomain.onmicrosoft.com**, and then select  **Next**.
+4. On the  **Sign in** page, type **Adam@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com**, and then select  **Next**.
 
 5. In the  **Enter password** box, type **Pa55w.rd**, and then select  **Sign in**.
 
@@ -360,11 +364,11 @@
 
 9. Close the  **Share “LocalDoc.dox”** dialog box.
 
-10. Sign out, and then sign in as  **Adatum\Abbi** by using a password of **Pa55w.rd**.
+10. Sign out, and then sign in as  **Adatum\\Abbi** by using a password of **Pa55w.rd**.
 
-11. Open  **Microsoft Edge**, in the address bar, type  **https://login.microsoftonline.com**, and then press Enter.
+11. Open  **Microsoft Edge**, in the address bar, type  [**https://portal.office.com**](https://portal.office.com), and then press Enter.
 
-12. Sign in as  **Abbi@yourdomain.onmicrosoft.com** by using a password of **Pa55w.rd**.
+12. Sign in as  **Abbi@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** by using a password of **Pa55w.rd**.
 
 13. On the  **Microsoft Office Home** page, select **OneDrive**.
 
@@ -388,11 +392,11 @@
 
 #### Task 7: Disable external sharing for all users
   
-1. On  **LON-CL2**, sign in as  **Adatum\Administrator** by using a password of **Pa55w.rd**.
+1. On  **LON-CL2**, sign in as  **Adatum\\Administrator** by using a password of **Pa55w.rd**.
 
-2. Open  **Microsoft Edge**, in the address bar, type  **https://login.microsoftonline.com**, and then press Enter.
+2. Open  **Microsoft Edge**, in the address bar, type  [**https://portal.office.com**](https://portal.office.com), and then press Enter.
 
-3. Sign in as  **GAdmin@yourtenant.onmicrosoft.com** by using your password.
+3. Sign in as  **GAdmin@*&lt;Initials&gt;&lt;MMDDYY&gt;*outlook.onmicrosoft.com** by using your password.
 
 4. When you receive a prompt to stay signed in, select  **No**.
 
@@ -410,7 +414,7 @@
 
 11. In the navigation pane, select  **Admin centers**, and then select  **OneDrive**.
 
-12. Select  **Sharing**, ** **and then scroll down.
+12. Select  **Sharing**, and then scroll down.
 
 13. Under  **External sharing**, for  **OneDrive**, select  **Only people in your organization**, and then select  **Save**.
 
@@ -437,13 +441,13 @@
   
 1. On  **LON-SVR1**, select  **Start**, and then select  **Server Manager**.
 
-2. In  **Server Manager**, select ** Manage**, and then select  **Add Roles and Features**.
+2. In  **Server Manager**, select **Manage**, and then select  **Add Roles and Features**.
 
 3. In the  **Add Roles and FeaturesWizard**, on the  **Before you begin** page, select **Next**.
 
 4. On the  **Select installation type** page, select **Remote Desktop Services installation**, and then select  **Next**.
 
-5. On the  **Select Deployment type** page, select **Quick Start**, and then select ** Next**.
+5. On the  **Select Deployment type** page, select **Quick Start**, and then select **Next**.
 
 6. On the  **Select deployment scenario** page, select **Session-based desktop deployment**, and then select  **Next**.
 
@@ -453,7 +457,7 @@
 
 9. Wait for the roles to be installed and for the server to restart.
 
-10. After the server restarts, sign in as  **Adatum\Administrator** by using the password of **Pa55w.rd**.
+10. After the server restarts, sign in as  **Adatum\\Administrator** by using the password of **Pa55w.rd**.
 
 11. Select  **Start** and select **Server Manager**.
 
@@ -469,7 +473,7 @@
   
 1. On  **LON-SVR1**, select  **Start**, and then select  **Server Manager**.
 
-2. In the navigation pane, select  **Remote Desktop Services**, ** **and then select  **Collections**.
+2. In the navigation pane, select  **Remote Desktop Services**, and then select  **Collections**.
 
 3. In the  **COLLECTIONS** area, right-click **QuickSessionCollection**, and then select  **Remove Collection**.
 
@@ -481,11 +485,11 @@
 
 7. On the  **Name the collection** page, in the **Name** text box, type **RemoteApp Collection**, and then select  **Next**.
 
-8. On the  **Specify RD Session Host server** page, select **LON-SVR1.Adatum.com**, select the  **Right Arrow** to add it to **Selected**, ** **and then select  **Next**.
+8. On the  **Specify RD Session Host server** page, select **LON-SVR1.Adatum.com**, select the  **Right Arrow** to add it to **Selected**, and then select  **Next**.
 
-9. On the  **Specify user groups** page, verify that the **ADATUM\Domain Users** group is listed, and then select **Next**.
+9. On the  **Specify user groups** page, verify that the **ADATUM\\Domain Users** group is listed, and then select **Next**.
 
-10. On the  **Specify user profile disks** page, clear the **Enable user profile disks** check box, ** **and then select  **Next**.
+10. On the  **Specify user profile disks** page, clear the **Enable user profile disks** check box, and then select  **Next**.
 
 11. On the  **Confirm selections** page, review the configured settings, and then select **Create**.
 
@@ -501,13 +505,12 @@
 
 3. In the  **Publish RemoteApp Programs** wizard, on the **Select RemoteApp programs** page, select the following RemoteApp programs, and then select **Next**:
 
-
 -  **Calculator**
 
 -  **Paint**
 
-
 -  **WordPad**
+
 4. On the  **Confirmation** page, select **Publish**.
 
 5. After the RemoteApp programs are published, select  **Close**.
@@ -568,7 +571,7 @@
 
 26. In the  **Password** and **Confirm password** boxes, type **Pa55w.rd**, and then select  **Next**.
 
-27. On the  **File to Export** page, in the **File name** box, type **C:\cert.pfx,** and then select **Next**.
+27. On the  **File to Export** page, in the **File name** box, type **C:\\cert.pfx,** and then select **Next**.
 
 28. On the  **Completing the Certificate Export Wizard** page, select **Finish**.
 
@@ -588,7 +591,7 @@
 
 4. Select  **RD Connection Broker - Enable Single Sign On**, and then select  **Select existing certificate**.
 
-5. In the  **Select Existing Certificate** dialog box, in the **Certificate path** box, type **C:\cert.pfx**.
+5. In the  **Select Existing Certificate** dialog box, in the **Certificate path** box, type **C:\\cert.pfx**.
 
 6. In the  **Password** box, type **Pa55w.rd**.
 
@@ -598,7 +601,7 @@
 
 9. Select  **RD Connection Broker - Publishing**, and then select  **Select existing certificate**.
 
-10. In the  **Select Existing Certificate** dialog box, in the **Certificate path** box, type **C:\cert.pfx**.
+10. In the  **Select Existing Certificate** dialog box, in the **Certificate path** box, type **C:\\cert.pfx**.
 
 11. In the  **Password** box, type **Pa55w.rd**.
 
@@ -608,7 +611,7 @@
 
 14. Select  **RD Web Access**, and then select  **Select existing certificate**.
 
-15. In the  **Select Existing Certificate** dialog box, in the **Certificate path** box, type **C:\cert.pfx**.
+15. In the  **Select Existing Certificate** dialog box, in the **Certificate path** box, type **C:\\cert.pfx**.
 
 16. In the  **Password** box, type **Pa55w.rd**.
 
@@ -620,6 +623,7 @@
 >  **Result**: After completing this exercise, you will have deployed RemoteApp programs.
 
 
+
 ## Exercise 2: Accessing published RemoteApp programs
   
 #### Task 1: Connect to RD Web Access
@@ -628,7 +632,7 @@
 
 2. In the address bar, type  **https://lon-svr1.adatum.com/rdweb**, and then press Enter.
 
-3. On the  **Work Resources** page, in the **Domain\user name** box, type **Adatum\Adam**.
+3. On the  **Work Resources** page, in the **Domain\\user name** box, type **Adatum\\Adam**.
 
 4. In the  **Password** box, type **Pa55w.rd**, and then select  **Sign in**.
 
@@ -652,7 +656,7 @@
 
 3. In the  **New GPO** dialog box, in the **Name** box, type **RDS SSO,** and then select **OK**.
 
-4. Right-click  **RDS SSO**, ** **and then select  **Edit**.
+4. Right-click  **RDS SSO**, and then select  **Edit**.
 
 5. In  **Group Policy Management Editor**, under  **Computer Configuration**, expand  **Policies**, expand  **Administrative Templates**, expand  **System**, and then select  **Credentials Delegation**.
 
@@ -666,7 +670,7 @@
 
 10. Close  **Group Policy Management Editor** and **Group Policy Management**.
 
-11. Restart  **LON-CL1**, and then sign in as  **Adatum\Adam** by using a password of **Pa55w.rd**.
+11. Restart  **LON-CL1**, and then sign in as  **Adatum\\Adam** by using a password of **Pa55w.rd**.
 
 
 
@@ -676,7 +680,7 @@
 
 2. In the address bar, type  **https://lon-svr1.adatum.com/rdweb**, and then press Enter.
 
-3. On the  **Work Resources** page, in the **Domain\user name** box, type **Adatum\Adam**.
+3. On the  **Work Resources** page, in the **Domain\\user name** box, type **Adatum\\Adam**.
 
 4. In the  **Password** box, type **Pa55w.rd**, and then select  **Sign in**.
 
@@ -698,7 +702,7 @@
 
 4. In the  **Ready to set up the connection** page, read the information, and then select **Next**.
 
-5. In the  **Windows Security** window, sign in as **Adatum\Administrator** by using a password of **Pa55w.rd**.
+5. In the  **Windows Security** window, sign in as **Adatum\\Administrator** by using a password of **Pa55w.rd**.
 
 6. On the  **You have successfully set up the following connection** page, select **Finish**.
 

--- a/Instructions/206972C_LAB_AK_11.md
+++ b/Instructions/206972C_LAB_AK_11.md
@@ -1,4 +1,4 @@
-# Lab Answer Key:  Module 11: Configuring and managing Client Hyper-V
+﻿# Lab Answer Key:  Module 11: Configuring and managing Client Hyper-V
 # Lab: Configuring and managing Client Hyper-V
   
 ## Exercise 1: Installing Client Hyper-V
@@ -7,100 +7,110 @@
   
 1. On  **LON-CL1**, on the taskbar, click  **Start**, type  **hyper-v**, and confirm that no match containing the word Hyper-V is found.
 
-2. On the taskbar, click  **Start**, type  **powershell**, ** **and then click  **Windows PowerShell**.
+2. On the taskbar, click  **Start**, type  **powershell**, and then click  **Windows PowerShell**.
 
 3. In the Windows PowerShell window, type the following cmdlet, and then press Enter:
 
   ```
-  Get-Command –Module Hyper-V 
+  Get-Command -Module Hyper-V 
   ```
 
 4. Verify that no cmdlet is listed.
 
-5. On the taskbar, click  **Start**, type  **features**, ** **and then click  **Turn Windows features on or off**.
+5. On the taskbar, click  **Start**, type  **features**, and then click  **Turn Windows features on or off**.
 
-6. In the  **Windows Features** dialog box, expand **Hyper-V**, expand  **Hyper-V Platform**, ** **and then click  **Hyper-V**. 
+6. In the  **Windows Features** dialog box, expand **Hyper-V**, expand  **Hyper-V Platform**, and then click  **Hyper-V**. 
 
 7. Verify that the Hyper-V Management Tools are selected, but Hyper-V Hypervisor and Hyper-V Services are grayed out and they cannot be selected.
+
 >  **Note:** You cannot install the Hyper-V Platform feature because **LON-CL1** does not meet the prerequisites for installing Client Hyper-V.
+
 8. In the  **Windows Features** dialog box, click **Cancel**.
 
-9. On the physical host computer, on the taskbar, click  **Start**, type  **powershell**, ** **and then click  **Windows PowerShell**.
+9. On the physical host computer, **HV-HOST**, on the taskbar, click  **Start**, type  **powershell**, and then click  **Windows PowerShell**.
 
 10. In the Windows PowerShell window, type the following cmdlet, and then press Enter:
 
   ```
-  Set-VMProcessor 20697-2C-LON-CL1 –ExposeVirtualizationExtensions $True
+  Set-VMProcessor 20697-2C-LON-CL1 -ExposeVirtualizationExtensions $True
   ```
+
 
 >  **Note:** You will get an error because **LON-CL1** is running and you can enable nested virtualization only if the virtual machine (VM) is turned off.
+
 11. On  **LON-CL1**, on the taskbar, right-click  **Start**, select  **Shut down or sign out**, and then click  **Shut down**.
 
-12. After  **20697-2C-LON-CL1** is turned off, on the physical host computer, In the Windows PowerShell window, type the following cmdlet, and then press Enter:
+12. After  **20697-2C-LON-CL1** is turned off, on the physical host computer, **HV-HOST**, in the Windows PowerShell window, type the following cmdlet, and then press Enter:
 
   ```
-  Set-VMProcessor 20697-2C-LON-CL1 –ExposeVirtualizationExtensions $True
+  Set-VMProcessor 20697-2C-LON-CL1 -ExposeVirtualizationExtensions $True
   ```
 
-13. On the  **20697-2C-LON-CL1** desktop, click **File**, and then click  **Settings**.
+13. On the physical host computer, **HV-HOST**, in **Hyper-V Manager**, double-click the **20697-2C-LON-CL1** VM, and in the **20697-2C-LON-CL1 on HV-HOST - Virtual Machine Connection** window, click **File**, and then select **Settings...**.
 
-14. In the navigation pane, click  **Memory**, and then in the details pane, in the  **RAM** text box, type **4096**.
+14. In **Settings for 20697-2C-LON-CL1 on HV-HOST** window, in the navigation pane, click  **Memory**, and then in the details pane, in the  **RAM** text box, type **4096**.
 
-15. In the navigation pane, expand  **Network Adapter**, and then click  **Advanced Features**. 
+15. In **Settings for 20697-2C-LON-CL1 on HV-HOST** window, in the navigation pane, expand  **Network Adapter**, and then click  **Advanced Features**. 
 
-16. In the details pane, select the  **Enable MAC address spoofing** check box, and then click **OK**.
+16. In **Settings for 20697-2C-LON-CL1 on HV-HOST** window, in the details pane, select the  **Enable MAC address spoofing** check box, and then click **OK**.
 
 
 
 #### Task 2: Install Client Hyper-V
   
-1. On  **LON-CL1**, , on the taskbar, click  **Start**. Wait until  **LON-CL1** starts and then sign in as **Adatum\Administrator** using **Pa55w.rd** as the password.
+1. On the physical host computer, **HV-HOST**, in the **20697-2C-LON-CL1 on HV-HOST - Virtual Machine Connection** window, click **Start**.  
+Wait until  **LON-CL1** starts, and then sign in as **Adatum\\Administrator**, using **Pa55w.rd** as the password.
 
-2. On  **LON-CL1**, on the taskbar, click  **Start**, type  **features**, ** **and then click  **Turn Windows features on or off**.
+2. On  **LON-CL1**, on the taskbar, click  **Start**, type  **features**, and then click  **Turn Windows features on or off**.
 
-3. In the  **Windows Features** dialog box, expand **Hyper-V**, expand  **Hyper-V Platform**, ** **and then click  **Hyper-V**. 
+3. On  **LON-CL1**, in the  **Windows Features** dialog box, expand **Hyper-V**, expand  **Hyper-V Platform**, and then click  **Hyper-V**. 
 
 4. Verify that this time Hyper-V Management Tools, Hyper-V Hypervisor, and Hyper-V Services are selected.
+
 >  **Note:** Because nested virtualization is enabled for **LON-CL1**, you were able to select all Hyper-V components.
-5. In the  **Windows Features** dialog box, click **OK**. 
+
+5. On  **LON-CL1**, in the  **Windows Features** dialog box, click **OK**. 
 
 6. Wait until the feature is installed, and then click  **Restart now**.
 
-7. On  **LON-CL1**, sign in as  **Adatum\Administrator** using **Pa55w.rd** as the password.
+7. On  **LON-CL1**, sign in as  **Adatum\\Administrator** using **Pa55w.rd** as the password.
 
-8. On the taskbar, click  **Start**, type  **powershell**, ** **and then click  **Windows PowerShell**.
+8. On  **LON-CL1**, on the taskbar, click  **Start**, type  **powershell**, and then click  **Windows PowerShell**.
 
-9. In the Windows PowerShell window, type the following cmdlet, and then press Enter:
-
+9. On  **LON-CL1**, in the Windows PowerShell window, type the following cmdlet, and then press Enter:
 
 ```
-Get-Command –Module Hyper-V 
+Get-Command -Module Hyper-V 
 ```
+
 
 >  **Note:** The output now shows many cmdlets, which confirms that the Microsoft Hyper V module is installed and available.
 
+ 
 >  **Result**: After completing this exercise, you should have enabled nested virtualization and installed the Client Hyper-V feature.
+
+
 
 
 ## Exercise 2: Creating a virtual switch, a virtual hard disk, and a VM
   
 #### Task 1: Create virtual switches
   
-1. On  **LON-CL1**, on the taskbar, click  **Start**, ** **and then click  **Hyper-V Manager**.
+1. On  **LON-CL1**, on the taskbar, click  **Start**, and then click  **Hyper-V Manager**.
 
-2. In Hyper-V Manager, in the navigation pane, click  **LON-CL1**. In the  **Actions** pane, click **Virtual Switch Manager**.
+2. On  **LON-CL1**, in Hyper-V Manager, in the navigation pane, click  **LON-CL1**. In the  **Actions** pane, click **Virtual Switch Manager**.
 
 3. In the Virtual Switch Manager window, confirm that in the  **Virtual Switches** section, **Default Switch** is the only virtual switch listed.
 
 4. In the  **Virtual Switch Manager** window, click **Cancel**. 
 
-5. On the taskbar, click  **Start**, type  **control**, ** **and then click  **Control Panel**.
+5. On  **LON-CL1**, on the taskbar, click  **Start**, type  **control**, and then click  **Control Panel**.
 
 6. In Control Panel, in the  **Search ControlPanel** text box, type **network**, and then click  **View network connections**.
 
-7. In the  **Network Connections** window, confirm that two network connections display: **Ethernet**, and  **vEthernet(Default Switch)**.
+7. In the  **Network Connections** window, confirm that two network connections display: **Ethernet**, and  **vEthernet (Default Switch)**.
 
-8. On the taskbar, click  **Hyper-V Manager**, and in the  **Actions** pane, click **Virtual Switch Manager**.
+8. On  **LON-CL1**, on the taskbar, click  **Hyper-V Manager**, and in the  **Actions** pane, click **Virtual Switch Manager**.
 
 9. In Virtual Switch Manager for  **LON-CL1**, in the navigation pane, confirm that  **New virtual network switch** is selected. In the details pane, click **Private**, and then click  **Create Virtual Switch**. 
 
@@ -114,7 +124,7 @@ Get-Command –Module Hyper-V
 
 14. In the details pane, in the  **Name** text box, type **Internal Switch**, and then click  **OK**.
 
-15. On the taskbar, click  **Network Connections**, and confirm that when you created the internal virtual switch, an additional network connection named  **vEthernet(Internal Switch)** was added.
+15. On the taskbar, click  **Network Connections**, and confirm that when you created the internal virtual switch, an additional network connection named  **vEthernet (Internal Switch)** was added.
 
 16. On the taskbar, click  **Hyper-V Manager**, and in the  **Actions** pane, click **Virtual Switch Manager**.
 
@@ -122,7 +132,7 @@ Get-Command –Module Hyper-V
 
 18. In the details pane, in the  **Name** text box, type **External Switch**, click  **OK**, and then click  **Yes**.
 
-19. On the taskbar, click  **Network Connections**, and confirm that when you created the external virtual switch, an additional network connection named  **vEthernet(External Switch)** was added.
+19. On the taskbar, click  **Network Connections**, and confirm that when you created the external virtual switch, an additional network connection named  **vEthernet (External Switch)** was added.
 
 20. On the taskbar, click  **Hyper-V Manager**, and in the  **Actions** pane, click **Virtual Switch Manager**.
 
@@ -143,13 +153,13 @@ Get-Command –Module Hyper-V
 
 2. In the  **New Virtual Hard Disk Wizard**, on the  **Before You Begin** page, click **Next**.
 
-3. On the  **Choose Disk Format** page, confirm that **VHDX** is selected, ** **and then click  **Next**.
+3. On the  **Choose Disk Format** page, confirm that **VHDX** is selected, and then click  **Next**.
 
-4. On the  **Choose Disk Type** page, ** **confirm that the default disk type for the virtual hard disk is  **Dynamically expanding**, and then click  **Next**.
+4. On the  **Choose Disk Type** page, confirm that the default disk type for the virtual hard disk is  **Dynamically expanding**, and then click  **Next**.
 
-5. On the  **Specify Name and Location** page, in the **Name** text box, type **Dynamic.vhdx**. In the  **Location** text box, type **C:\VMs**, and then click ** Next**.
+5. On the  **Specify Name and Location** page, in the **Name** text box, type **Dynamic.vhdx**. In the  **Location** text box, type **C:\\VMs**, and then click **Next**.
 
-6. On the  **Configure Disk** page, confirm that **Create a new blank virtual hard disk** is selected. In the **Size** field, type ** 100**, and then click  **Next**.
+6. On the  **Configure Disk** page, confirm that **Create a new blank virtual hard disk** is selected. In the **Size** field, type **100**, and then click  **Next**.
 
 7. On the  **Completing the New Virtual Hard Disk Wizard** page, click **Finish**.
 
@@ -159,27 +169,27 @@ Get-Command –Module Hyper-V
 
 10. On the  **Choose Disk Format** page, click **VHD**, and then click  **Next**.
 
-11. On ** **the  **Choose Disk Type** page, ** **click  **Differencing**, ** **and then click  **Next**.
+11. On the  **Choose Disk Type** page, click  **Differencing**, and then click  **Next**.
 
-12. On the  **Specify Name and Location** page, in the **Name** text box, type **Differencing.vhd**. ** **In the  **Location** text box, type **C:\VMs**, and then click ** Next**.
+12. On the  **Specify Name and Location** page, in the **Name** text box, type **Differencing.vhd**. In the  **Location** text box, type **C:\\VMs**, and then click **Next**.
 
-13. On the  **Configure Disk** page, click **Browse**, and then browse to  **E:\Labfiles\Mod11**.
+13. On the  **Configure Disk** page, click **Browse**, and then browse to  **E:\\Labfiles\\Mod11**.
 
-14. In the  **Mod11** folder, click **Base18A-W10-1709.vhd**, ** **click  **Open**, and then click  **Next**.
+14. In the  **Mod11** folder, click **Base18A-W10-1709.vhd**, click  **Open**, and then click  **Next**.
 
 15. On the  **Completing the New Virtual Hard Disk Wizard** page, click **Finish**.
 
-16. On the taskbar, click  **Start**, ** **type  **powershell**, ** **and then click  **Windows PowerShell**. ** **
+16. On the taskbar, click  **Start**, type  **powershell**, and then click  **Windows PowerShell**. 
 
 17. In Windows PowerShell, create a fixed-size virtual hard disk by typing the following cmdlet, and then pressing Enter:
 
   ```
-  New-VHD –Path C:\VMs\Fixed.vhdx -SizeBytes 1GB –Fixed
+  New-VHD -Path C:\VMs\Fixed.vhdx -SizeBytes 1GB -Fixed
   ```
 
 18. On the taskbar, click the  **File Explorer** icon.
 
-19. In File Explorer, expand  **Local Disk (C:)**, and then click  **VMs**. ** **
+19. In File Explorer, expand  **Local Disk (C:)**, and then click  **VMs**. 
 
 20. In the details pane, confirm that the three virtual hard disks that you created display.
 
@@ -187,7 +197,7 @@ Get-Command –Module Hyper-V
 
 22. Confirm that the size on the disk is  **1.00 GB**, and then click  **OK**.
 
-23. In File Explorer, verify that both  **Dynamic.vhdx** and **Differencing.vhd** are ** **allocated much less space on the disk, even though you configured  **Dynamic.vhdx** with 100 gigabytes (GB).
+23. In File Explorer, verify that both  **Dynamic.vhdx** and **Differencing.vhd** are allocated much less space on the disk, even though you configured  **Dynamic.vhdx** with 100 gigabytes (GB).
 
 
 
@@ -205,25 +215,27 @@ Get-Command –Module Hyper-V
 
 6. On the  **Configure Networking** page, in the **Connection** drop-down list box, verify that all the switches that you created are available.
 
-7. Select  **External Switch**, ** **and then click  **Next**.
+7. Select  **External Switch**, and then click  **Next**.
 
-8. On the  **Connect Virtual Hard Disk** page, select the **Use an existing virtual hard disk** option. In the **Location** text box, type **C:\VMs\Differencing.vhd**, ** **and then click  **Next**.
+8. On the  **Connect Virtual Hard Disk** page, select the **Use an existing virtual hard disk** option. In the **Location** text box, type **C:\\VMs\\Differencing.vhd**, and then click  **Next**.
 
 9. On the  **Completing the Virtual Machine Wizard** page, click **Finish**. 
 
-10. Verify that a VM named VM1 ** **has been created.
+10. Verify that a Virtual Machine named **VM1** has been created.
 
-11. In Hyper-V Manager, right-click  **VM1**, and then click  **Start**. Notice that a checkpoint of VM1 has been created automatically.
+11. On  **LON-CL1**, in Hyper-V Manager, right-click  **VM1**, and then click  **Start**. Notice that a checkpoint of VM1 has been created automatically.
 
-12. Right-click  **VM1**, ** **and then click  **Settings**.
+12. Right-click  **VM1**, and then click  **Settings**.
 
-13. In the navigation pane, click  **SCSI Controller**. In the details pane, click  **Hard Drive**, click  **Add**, ** **and in the  **Virtual hard disk** text box, type **C:\VMs\Fixed.vhdx**.
+13. In the navigation pane, click  **SCSI Controller**. In the details pane, click  **Hard Drive**, click  **Add**, and in the  **Virtual hard disk** text box, type **C:\\VMs\\Fixed.vhdx**.
 
-14. In the navigation pane, click  **SCSI Controller**. In the details pane, click  **Hard Drive**, and then click  **Add**. In the  **Virtual hard disk** textbox, type **C:\VMs\Dynamic.vhd**.
+14. In the navigation pane, click  **SCSI Controller**. In the details pane, click  **Hard Drive**, and then click  **Add**. In the  **Virtual hard disk** textbox, type **C:\\VMs\\Dynamic.vhd**.
 
-15. In the navigation pane, click  **Memory**. In the details pane, in the  **RAM** textbox, type **1500**, ** **and then click  **OK**.
+15. In the navigation pane, click  **Memory**. In the details pane, in the  **RAM** textbox, type **1500**, and then click  **OK**.
+
 >  **Note:** You were able to add virtual hard disks and modify the amount of memory while VM1 was running.
-16. In Hyper-V Manager, in the  **Actions** pane, click **New**, and then click  **Virtual Machine**.
+
+16. On  **LON-CL1**, in Hyper-V Manager, in the  **Actions** pane, click **New**, and then click  **Virtual Machine**.
 
 17. In the  **New Virtual Machine Wizard**, on the  **Before You Begin** page, click **Next**.
 
@@ -235,9 +247,9 @@ Get-Command –Module Hyper-V
 
 21. On the  **Completing the Virtual Machine Wizard** page, click **Finish**. 
 
-22. Verify that a VM named VM2 ** **has been created.
+22. Verify that a Virtual Machine named **VM2** has been created.
 
-23. In Hyper-V Manager, right-click  **VM2**, and then click  **Settings**.
+23. On  **LON-CL1**, in Hyper-V Manager, right-click  **VM2**, and then click  **Settings**.
 
 24. In the  **Settings for VM2 on LON-CL1** window, in the navigation pane, click **Security**. In the details pane, click  **Enable Trusted Platform Module**, and then click  **OK**.
 
@@ -245,9 +257,11 @@ Get-Command –Module Hyper-V
 
 26. Right-click  **VM2**, and then click  **Settings**.
 
-27. In the  **Settings for VM2 on LON-CL1** window, in the details pane, click **Network Adapter**, and then click  **Add**. In the  **Virtual switch** drop-down list box, select **Private Switch**, ** **and then click  **OK**.
+27. In the  **Settings for VM2 on LON-CL1** window, in the details pane, click **Network Adapter**, and then click  **Add**. In the  **Virtual switch** drop-down list box, select **Private Switch**, and then click  **OK**.
+
 >  **Note:** You now have added a network adapter to Generation 2 VM while VM was running.
-28. In Hyper-V Manager, right-click  **VM2**, and then click  **Turn Off**. Notice that the VM2 checkpoint that was automatically created has been deleted.
+
+28. On  **LON-CL1**, in Hyper-V Manager, right-click  **VM2**, and then click  **Turn Off**. Notice that the VM2 checkpoint that was automatically created has been deleted.
 
 
 
@@ -257,13 +271,13 @@ Get-Command –Module Hyper-V
 
 2. In the  **Connect to VM1** dialog box, select **Display configuration** of **800 by 600 pixels**, and then click  **Connect**.
 
-3. On VM1, sign in as  **Admin** and use **Pa55w.rd** as the password.
+3. On **VM1**, sign in as  **Admin** and use **Pa55w.rd** as the password.
 
-4. On VM1, on the taskbar, right-click  **Start**, and then click  **Disk Management**.
+4. On **VM1**, on the taskbar, right-click  **Start**, and then click  **Disk Management**.
 
 5. In Disk Management, verify that three disks display to represent the differencing, fixed size, and dynamically expanding disks that you created earlier in the lab.
 
-6. Right-click  **Disk 1**, click  **Initialize Disk**, ** **and then click  **OK**.
+6. Right-click  **Disk 1**, click  **Initialize Disk**, and then click  **OK**.
 
 7. Right-click the unallocated space on Disk 1, click  **New Simple Volume**, click  **Next** four times, and then click **Finish**.
 
@@ -274,15 +288,15 @@ Get-Command –Module Hyper-V
 10. On  **LON-CL1**, in Windows PowerShell, type the following two cmdlets, pressing Enter after each cmdlet:
 
   ```
-  Resize-VHD C:\VMs\Fixed.vhdx –SizeBytes 2GB 
+  Resize-VHD C:\VMs\Fixed.vhdx -SizeBytes 2GB 
   ```
 
 
   ```
-  Resize-VHD C:\VMs\Dynamic.vhdx –SizeBytes 150GB
+  Resize-VHD C:\VMs\Dynamic.vhdx -SizeBytes 150GB
   ```
 
-11. On VM1, in Disk Management, click  **Action**, ** **and then click  **Rescan Disks**.
+11. On **VM1**, in Disk Management, click  **Action**, and then click  **Rescan Disks**.
 
 12. Verify that 1 GB of unallocated space is added to Disk 1, and 50 GB of unallocated space is added to Disk 2. You extended both disks while they were in use.
 
@@ -292,87 +306,129 @@ Get-Command –Module Hyper-V
 
 15. On  **LON-CL1**, on the taskbar, click  **File Explorer**.
 
-16. In File Explorer, open the C:\VMs folder.
+16. In File Explorer, open the C:\\VMs folder.
 
 17. In the details pane, verify the size of the Fixed.vhdx, Dynamic.vhdx, and Differencing.vhd virtual hard disks.
 
->  **Note:** You extended Fixed.vhdx to 2 GB. The Dynamic.vhdx size has also increased, although it is considerably smaller than 150 GB. The Differencing.vhd size has also increased because new data was written to it.
+    >  **Note:** You extended Fixed.vhdx to 2 GB. The Dynamic.vhdx size has also increased, although it is considerably smaller than 150 GB. The Differencing.vhd size has also increased because new data was written to it.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have created different types of virtual switches, virtual hard disks, and VMs.
+
 
 
 ## Exercise 3: Using Integration Services and checkpoints
   
 #### Task 1: Configure Integration Services
   
-1. On VM1, on the taskbar, click  **Start**, type  **service**, ** **and then click  **Services**.
+1. On **VM1**, on the taskbar, click  **Start**, type  **service**, and then click  **Services**.
 
-2. In the  **Services** window, in the details pane, confirm that the Hyper-V Time Synchronization Service is running, and that the Hyper-V Guest Service Interface is not running.
+2. In the  **Services** window, in the details pane, confirm that the **Hyper-V Time Synchronization Service** is **running**, and that the **Hyper-V Guest Service Interface** is **not running**.
 
-3. On VM1, on the taskbar, right-click  **Start**, click  **Windows PowerShell (Admin)**, ** **and then click  **Yes**.
+3. On **VM1**, on the taskbar, right-click  **Start**, click  **Windows PowerShell (Admin)**, and then click  **Yes**.
 
-4. In the Windows PowerShell window, type the following command, ** ** and then press Enter:
+4. On **VM1**, in the Windows PowerShell window, type the following command,  and then press Enter:
 
   ```
   Get-Date 
   ```
 
-5. Make note of the current time, type  **Set-Date 11:00** as the current time, and then press Enter.
+5. Make note of the current time on VM1.
 
-6. In the Windows PowerShell window, type  **Get-Date**, ** **and then press Enter. 
+6. On **VM1**, in Windows PowerShell, type the following command, and then press Enter:
 
-7. Verify that the time was automatically set back to its previous value. This occurred because Integration Services automatically synchronized the time on VM1 ** **with the time on  **LON-CL1**.
+  ```
+  Set-Date 11:00
+  ```
 
-8. On  **LON-CL1**, on the taskbar, click  **File Explorer**.
+7. On **VM1**, in Windows PowerShell, type the following command, and then press Enter:
 
-9. In File Explorer, in the navigation pane, click  **Allfiles (E:)**. In the details pane, right-click an empty space, click  **New**, click  **Text Document**, type  **File1** as the file name, and then press Enter.
+  ```
+  Get-Date
+  ``` 
 
-10. Double-click  **File1.txt**. In the file, type your name. Close Notepad, and then click  **Save**.
+8. Verify that the time was automatically set back to its previous value. This occurred because Integration Services automatically synchronized the time on VM1 with the time on  **LON-CL1**.
 
-11. On  **LON-CL1**, in Windows PowerShell, type the following cmdlet, and then press Enter: 
+9. On  **LON-CL1**, on the taskbar, click  **File Explorer**.
+
+10. On  **LON-CL1**, in File Explorer, in the navigation pane, click  **Allfiles (E:)**. In the details pane, right-click an empty space, click  **New**, click  **Text Document**, type  **File1** as the file name, and then press Enter.
+
+11. On  **LON-CL1**, double-click  **File1.txt**. In the file, type your name. Close Notepad, and then click  **Save**.
+
+12. On  **LON-CL1**, in Windows PowerShell, type the following cmdlet, and then press Enter: 
 
   ```
   Copy-VMFile VM1 -SourcePath E:\File1.txt -DestinationPath C:\ -FileSource Host
   ```
+
 
 >  **Note:** You will get an error because the Guest Service Interface is not running in VM1.
-12. On ** LON-CL1**, in Hyper-V Manager, in the details pane, right-click  **VM1**, ** **and then click  **Settings**. 
 
-13. In  **Settings for VM1 on LON-CL1**, in the navigation ** **pane, click  **Integration Services**. In the details pane, select the  **Guest services** check box, ** **clear the  **Time synchronization** check box, and then click **OK**.
+13. On **LON-CL1**, in Hyper-V Manager, in the details pane, right-click  **VM1**, and then click  **Settings**. 
 
-14. On VM1, in Services, right-click  **Services (Local)**, and then click  **Refresh**. 
+14. In  **Settings for VM1 on LON-CL1**, in the navigation pane, click  **Integration Services**. In the details pane, select the  **Guest services** check box, clear the  **Time synchronization** check box, and then click **OK**.
 
-15. Confirm that the Hyper-V Time Synchronization Service is not running, but the Hyper-V Guest Service Interface is running.
+15. On **VM1**, in Services, right-click  **Services (Local)**, and then click  **Refresh**. 
 
-16. Close the  **Services** window.
+16. Confirm that the **Hyper-V Time Synchronization Service** is **not running**, but the **Hyper-V Guest Service Interface** is **running**.
 
-17. On VM1, in Windows PowerShell, type  **Get-Date**, and then press Enter. 
+17. Close the  **Services** window.
 
-18. Make note of the current time.
+18. On **VM1**, in Windows PowerShell, type the following command, and then press Enter:
 
-19. In Windows PowerShell, type  **Set-Date 11:00** as the current time, and then press Enter again.
+  ```
+  Get-Date
+  ```
 
-20. Type  **Get-Date**, and then press Enter. 
+19. Make note of the current time reported on VM1.
 
-21. Confirm that the returned time is a few seconds after  **11:00**. The time is off because the time on the VM is no longer synchronizing with the  **LON-CL1**.
+20. On **VM1**, in Windows PowerShell, type the following command, and then press Enter:
 
-22. Type  **dir C:\**, ** **and then press Enter to verify that  **File1.txt** does not exist on drive C.
+  ```
+  Set-Date 11:00
+  ```
 
-23. On  **LON-CL1**, in Windows PowerShell, run the same cmdlet as earlier to copy the file in VM1: 
+21. On **VM1**, in Windows PowerShell, type the following command, and then press Enter:
+
+  ```
+  Get-Date
+  ``` 
+
+22. Confirm that the returned time is a few seconds after  **11:00 AM**.  
+The time is off because the time on the VM is no longer synchronizing with the  **LON-CL1**.
+
+23. On **VM1**, in Windows PowerShell, type the following command, and then press Enter:
+
+  ```
+  dir C:\
+  ```
+
+24. Verify that  **File1.txt** does not exist on drive C:.
+
+25. On  **LON-CL1**, in Windows PowerShell, run the same cmdlet as earlier to copy the file in VM1: 
 
   ```
   Copy-VMFile VM1 -SourcePath E:\File1.txt -DestinationPath C:\ -FileSource Host
   ```
 
-24. On VM1, in Windows PowerShell, type  **dir C:\**, ** **and the press Enter.
+26. On **VM1**, in Windows PowerShell, type the following command, and then press Enter:
 
-25. Confirm that  **File1.txt** now exists ** **on drive C.
+  ```
+  dir C:\
+  ```
 
-26. In Windows PowerShell, type  **notepad C:\File1.txt**, ** **and then press Enter. 
+27. Confirm that  **File1.txt** now exists on drive C.
 
-27. Verify that the file displays.
+28. On **VM1**, in Windows PowerShell, type the following command, and then press Enter:
 
-28. Close Notepad, and then minimize the Windows PowerShell window.
+  ```
+  notepad C:\File1.txt
+  ```
+
+29. Verify that the file displays.
+
+30. On **VM1**, close Notepad, and then minimize the Windows PowerShell window.
 
 
 
@@ -380,51 +436,58 @@ Get-Command –Module Hyper-V
   
 1. On  **LON-CL1**, in Hyper-V Manager, right-click  **VM1**, and then click  **Settings**. 
 
-2. In Settings for ** **VM1, in the navigation pane, under  **SCSI Controller**, click  **Hard Drive**, and confirm that it is using the  **Fixed.vhdx** virtual hard disk.
+2. In Settings for VM1, in the navigation pane, under  **SCSI Controller**, click  **Hard Drive**, and confirm that it is using the  **Fixed.vhdx** virtual hard disk.
 
-3. In the navigation pane, click  **Checkpoints**. In the details pane, confirm that the  **Standard checkpoints** option is selected, and then click ** OK**.
+3. In the navigation pane, click  **Checkpoints**. In the details pane, confirm that the  **Standard checkpoints** option is selected, and then click **OK**.
 
-4. In Hyper-V Manager, ** **right-click  **VM1**, ** **and then click  **Checkpoint**. Wait a few seconds, and then verify in the Checkpoints ** **pane that a checkpoint named VM1 is added.
+4. In Hyper-V Manager, right-click  **VM1**, and then click  **Checkpoint**. Wait a few seconds, and then verify in the Checkpoints pane that a checkpoint named VM1 is added.
 
 5. On the taskbar, click  **VM1**.
 
-6. In VM1, right-click the desktop, click  **New**, ** **and then ** **click  **Folder**. Name the folder  **Folder1**.
+6. In **VM1**, right-click the desktop, click  **New**, and then click  **Folder**. Name the folder  **Folder1**.
 
-7. In the  **VM1 on LON-CL1 – Virtual Machine Connection** window, in the **Action** menu, click **Checkpoint**, type  **Folder1** as **Checkpoint Name**, ** **and then click ** Yes**, and then click ** OK.**
+7. In the  **VM1 on LON-CL1 - Virtual Machine Connection** window, in the **Action** menu, click **Checkpoint**, type  **Folder1** as **Checkpoint Name**, and then click **Yes**, and then click **OK.**
 
-8. In the  **VM1 on LON-CL1– Virtual Machine Connection** window, in the **File** menu, click **Settings**.
+8. In the  **VM1 on LON-CL1- Virtual Machine Connection** window, in the **File** menu, click **Settings**.
 
-9. In Settings for ** **VM1, in the navigation pane, under  **SCSI Controller**, click  **Hard Drive**. In the details pane, verify that the virtual hard disk name starts with Fixed, but it contains GUID in its name.
+9. In Settings for VM1, in the navigation pane, under  **SCSI Controller**, click  **Hard Drive**. In the details pane, verify that the virtual hard disk name starts with Fixed, but it contains GUID in its name.
+
 >  **Note:** This is a differencing disk, which was created by the checkpoint.
-10. In the navigation pane, click  **Checkpoints**. In the details pane, select the  **Production checkpoints** option, and then click ** OK**.
 
-11. On VM1, right-click the desktop, click  **New**, ** **click  **Folder**, and then name the folder ** Folder2**.
+10. In the navigation pane, click  **Checkpoints**. In the details pane, select the  **Production checkpoints** option, and then click **OK**.
 
-12. In the  **VM1 on LON-CL1 – Virtual Machine Connection** window, in the **Action** menu, click **Checkpoint**. Type  **Folder2** as the **Checkpoint Name**, ** **click ** Yes**, and then click  **OK**.
+11. On VM1, right-click the desktop, click  **New**, click  **Folder**, and then name the folder **Folder2**.
+
+12. In the  **VM1 on LON-CL1 - Virtual Machine Connection** window, in the **Action** menu, click **Checkpoint**. Type  **Folder2** as the **Checkpoint Name**, click **Yes**, and then click  **OK**.
 
 13. On  **LON-CL1**, in Hyper-V Manager, in the  **Checkpoints** pane, verify that VM1 has four checkpoints.
 
-14. Right-click ** **the ** Folder1** checkpoint, and then click ** Apply**. 
+14. Right-click the **Folder1** checkpoint, and then click **Apply**. 
 
 15. In the  **Apply Checkpoint** dialog box, click **Apply**.
 
-16. On VM1, sign in as  **Admin**, ** **using  **Pa55w.rd** as the password.
+16. On VM1, sign in as  **Admin**, using  **Pa55w.rd** as the password.
 
 17. On the desktop, confirm that there is only one folder, named  **Folder1**.
 
 18. On the taskbar, click  **Windows PowerShell** and confirm that it shows the cmdlets that you ran earlier.
+
 >  **Note:** You have just applied a standard checkpoint, which includes memory content.
-19. On  **LON-CL1**, in Hyper-V Manager, right-click  **Folder2** checkpoint, and then click ** Apply**. In the  **Apply Checkpoint** dialog box, click **Apply** and then click **Reconnect**.
+
+19. On  **LON-CL1**, in Hyper-V Manager, right-click  **Folder2** checkpoint, and then click **Apply**. In the  **Apply Checkpoint** dialog box, click **Apply** and then click **Reconnect**.
 
 20. In the  **VM1 on LON-CL1 – Virtual Machine Connection** window, click **Start**, and wait until the sign-in screen is shown.
 
-21. On VM1, sign in as  **Admin** and use **Pa55w.rd** as the password.
+21. On **VM1**, sign in as  **Admin** and use **Pa55w.rd** as the password.
 
-22. On the desktop, confirm that the Folder1 and Folder2 folders are available Verify that no running program is shown on the taskbar. 
+22. On **VM1**, on the desktop, confirm that the Folder1 and Folder2 folders are available and verify that no running programs are shown on the taskbar. 
 
->  **Note:** You applied a production checkpoint. Because a production checkpoint does not include memory content, the VM must go through the startup process when you apply a production checkpoint.
+    >  **Note:** You applied a production checkpoint. Because a production checkpoint does not include memory content, the VM must go through the startup process when you apply a production checkpoint.
+
+<!-- -->
 
 >  **Result**: After completing this exercise, you should have configured Integration Services, and created and applied checkpoints.
+
 
 
 


### PR DESCRIPTION
Escape characters for backslash not in a code block, Note line spacing, and stray "\*\*  \*\*"
(At Line 30 of Lab_AK_02, I'm not sure if that bold is warranted, the stray "\*\* \*\*" may just need to be deleted.)
In Lab_02, I converted the table into a bullet list (couldn't find a way to get a table without numbering when using pandoc).
Pandoc fixes for all files; changes made to LAB_AK_11 to clarify which machine is referenced by each step.
Note that a lot of these problems do not show on the web page, but become apparent when using the pandoc conversion.